### PR TITLE
Fix broken isPrinterConnected() function calling undefined function exists()

### DIFF
--- a/node-thermal-printer.js
+++ b/node-thermal-printer.js
@@ -231,7 +231,7 @@ module.exports = {
     if(printerConfig.interface){
       var fs = require('fs');
       fs.exists(printerConfig.interface, function(ex){
-        exists(ex);
+        return ex;
       });
     }
 


### PR DESCRIPTION
Currently the isPrinterConnected() function is broken and non-function as it does not return the fs.exists() result and instead calls exists(ex) which looks to be a typo.  I've corrected this by returning the fs.exists() response.

Great library by the way. Appreciate your hard work in building it.