### PR TITLE
Added callback support for execute() and raw() methods for error checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ printer.init({
   characterSet: 'SLOVENIA'                          // Printer character set
 });
 
-printer.isPrinterConnected( function(isConnected){ } ) // Check if printer is connected, callback passes bool of status
-printer.execute();                                  // Executes all the commands
-printer.raw(new Buffer("Hello world"));             // Print instantly
-printer.print("Hello World");                       // Append text
-printer.println("Hello World");                     // Append text with new line
-printer.cut();                                      // Cuts the paper
+printer.isPrinterConnected( function(isConnected){ } )     // Check if printer is connected, callback passes bool of status
+printer.execute( function(err){ } );                       // Executes all the commands. Optional callback returns null if no error, else error message
+printer.raw(new Buffer("Hello world"), function(err){ } ); // Print instantly. Optional callback returns null if no error, else error message
+printer.print("Hello World");                              // Append text
+printer.println("Hello World");                            // Append text with new line
+printer.cut();                                             // Cuts the paper
 
 printer.bold(true);                                 // Set text bold
 printer.drawLine();                                 // Draws a line
@@ -80,5 +80,11 @@ printer.init({
 printer.alignCenter();
 printer.println("Hello world");
 printer.cut();
-printer.execute();
+printer.execute(function(err){
+  if (err) {
+    console.error("Print failed", err);
+  } else {
+   console.log("Print done");
+  }
+});
 ```

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ printer.println("Hello World");                            // Append text with n
 printer.cut();                                             // Cuts the paper
 
 printer.bold(true);                                 // Set text bold
+printer.underline(true);                            // Underline text (1 dot thickness)
+printer.underlineThick(true);                       // Underline text with thick line (2 dot thickness)
 printer.drawLine();                                 // Draws a line
 printer.newLine();                                  // Insers break line
 

--- a/node-thermal-printer.js
+++ b/node-thermal-printer.js
@@ -26,7 +26,7 @@ module.exports = {
     printerConfig = initConfig;
   },
 
-  execute: function(){
+  execute: function(cb){
     if(printerConfig.ip){
       var printer = net.connect({
         host : printerConfig.ip,
@@ -38,10 +38,18 @@ module.exports = {
     } else {
       writeFile(printerConfig.interface , buffer, function (err) {
         if (err) {
-          console.error('Print failed', err);
+          if ("function" == typeof cb) {
+            cb("Print failed: " + err);
+          } else {
+            console.error("Print failed", err);
+          }
         } else {
-          console.log('Print done');
           buffer = null;
+          if ("function" == typeof cb) {
+            cb( null );
+          } else {
+            console.log("Print done");
+          }
         }
       });
     }
@@ -513,7 +521,7 @@ module.exports = {
     }
   },
 
-  raw: function(text) {
+  raw: function(text,cb) {
     if (printerConfig.ip) {
       var printer = net.connect({
         host: printerConfig.ip,
@@ -525,9 +533,17 @@ module.exports = {
     } else {
       writeFile(printerConfig.interface, text, function (err) {
         if (err) {
-          console.error('Print failed', err);
+          if ('function' == typeof cb) {
+            cb("Print failed: " + err);
+          } else {
+            console.error("Print failed", err);
+          }
         } else {
-          console.log('Print done');
+          if ('function' == typeof cb) {
+            cb("Print failed: " + err);
+          } else {
+            console.log("Print done");
+          }
         }
       });
     }

--- a/node-thermal-printer.js
+++ b/node-thermal-printer.js
@@ -99,6 +99,16 @@ module.exports = {
     if(enabled) append(config.TXT_BOLD_ON);
     else append(config.TXT_BOLD_OFF);
   },
+  
+  underline: function(enabled){
+    if(enabled) append(config.TXT_UNDERL_ON);
+    else append(config.TXT_UNDERL_OFF);
+  },
+
+  underlineThick: function(enabled){
+    if(enabled) append(config.TXT_UNDERL2_ON);
+    else append(config.TXT_UNDERL2_OFF);
+  },
 
   alignCenter: function (){
     append(config.TXT_ALIGN_CT);


### PR DESCRIPTION
Hello again!

This pull request adds OPTIONAL callback support to the execute() and raw() functions so any possible errors can be programmatically accessed. This makes it so that a detected print failure can be handled.  I needed this for my uses so I figure others may as well.

Return value is either null (no errors) or the string error message that would be echo'd out as before, as returned by the callback from the writeFile() call.

When not using a callback everything functions as it had before this change so it's backward compatible and the callback is fully optional.