### PR TITLE
Added invert, partialCut, and beep functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,12 @@ printer.raw(new Buffer("Hello world"), function(err){ } ); // Print instantly. O
 printer.print("Hello World");                              // Append text
 printer.println("Hello World");                            // Append text with new line
 printer.openCashDrawer();                                  // Kick the cash drawer
-printer.cut();                                             // Cuts the paper
+printer.cut();                                             // Cuts the paper (if printer only supports one mode use this)
+printer.partialCut();                                      // Cuts the paper leaving a small bridge in middle (if printer supports multiple cut modes)
+printer.beep();                                            // Sound internal beeper/buzzer (if available)
 
 printer.bold(true);                                 // Set text bold
+printer.invert(true);                               // Background/text color inversion
 printer.underline(true);                            // Underline text (1 dot thickness)
 printer.underlineThick(true);                       // Underline text with thick line (2 dot thickness)
 printer.drawLine();                                 // Draws a line

--- a/configs/epsonConfig.js
+++ b/configs/epsonConfig.js
@@ -11,6 +11,7 @@ module.exports = {
     HW_INIT    : new Buffer([0x1b, 0x40]),          // Clear data in buffer and reset modes
     HW_SELECT  : new Buffer([0x1b, 0x3d, 0x01]),      // Printer select
     HW_RESET   : new Buffer([0x1b, 0x3f, 0x0a, 0x00]),  // Reset printer hardware
+    BEEP       : new Buffer([0x1b, 0x1e]),              // Sounds built-in buzzer (if equipped)
 
     // Cash Drawer
     CD_KICK_2  : new Buffer([0x1b, 0x70, 0x00]),      // Sends a pulse to pin 2 []
@@ -30,6 +31,8 @@ module.exports = {
     TXT_UNDERL2_ON  : new Buffer([0x1b, 0x2d, 0x02]), // Underline font 2-dot ON
     TXT_BOLD_OFF    : new Buffer([0x1b, 0x45, 0x00]), // Bold font OFF
     TXT_BOLD_ON     : new Buffer([0x1b, 0x45, 0x01]), // Bold font ON
+    TXT_INVERT_OFF  : new Buffer([0x1d, 0x42, 0x00]), // Invert font OFF (eg. white background)
+    TXT_INVERT_ON   : new Buffer([0x1d, 0x42, 0x01]), // Invert font ON (eg. black background)
     TXT_FONT_A      : new Buffer([0x1b, 0x4d, 0x00]), // Font type A
     TXT_FONT_B      : new Buffer([0x1b, 0x4d, 0x01]), // Font type B
     TXT_ALIGN_LT    : new Buffer([0x1b, 0x61, 0x00]), // Left justification

--- a/node-thermal-printer.js
+++ b/node-thermal-printer.js
@@ -61,6 +61,21 @@ module.exports = {
     append(config.PAPER_FULL_CUT);
     append(config.HW_INIT);
   },
+  
+  partialCut: function(){
+    append(config.CTL_VT);
+    append(config.CTL_VT);
+    append(config.PAPER_PART_CUT);
+    append(config.HW_INIT);
+  },
+
+  beep: function(){
+    if (printerConfig.type == 'star'){
+      console.error("Beep not supported on STAR yet");
+      return;
+    }
+    append(config.BEEP);
+  },
 
   getWidth: function(){
     return parseInt(printerConfig.width);
@@ -108,6 +123,15 @@ module.exports = {
   underlineThick: function(enabled){
     if(enabled) append(config.TXT_UNDERL2_ON);
     else append(config.TXT_UNDERL_OFF);
+  },
+  
+  invert: function(enabled){
+    if (printerConfig.type == 'star'){
+      console.error("Invert not supported on STAR yet");
+      return;
+    }
+    if(enabled) append(config.TXT_INVERT_ON);
+    else append(config.TXT_INVERT_OFF);
   },
 
   openCashDrawer: function(){


### PR DESCRIPTION
invert:
Inverts the foreground and background colors of text. Eg if by default your printer prints black text on a white paper, this will change the background to be black while leaving the text color 'empty', aka the printer paper, results in white text on a black background. I added new configuration command codes from the Epson manual. Functions similarly to the bold command.

partialCut:
For printers only supporting one paper cut type the existing cut() function works fine. However if your printer supports two modes, cut() defaults to a 'full' cut while partialCut() will leave a bridge in the middle, keeping the paper slightly connected. This configuration code already existed but without an accompanying function.

beep:
Many models do not support the beep command but I happen to have one that does. I added the configuration command code for this. It can be used multiple times in a row any time during the print to beep a ~200ms tone. Some Epson documentation calls this buzz.

I have tested all of these new functions and they work fine for me.  Note that partialCut and beep are only usable on some models.  I believe invert is pretty widely available.  I also updated the readme and tried to keep my code in the same formats of existing code in the project.

Thanks!