### PR TITLE
Dependency-Update: node-png -> pngjs

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -1,6 +1,6 @@
 var fs = require('fs'),
     net = require("net"),
-    PNG = require('node-png').PNG,
+    PNG = require('pngjs').PNG,
     star = require('./star'),
     epson = require('./epson');
 

--- a/lib/epson.js
+++ b/lib/epson.js
@@ -1,5 +1,5 @@
 let fs = require('fs');
-let PNG = require('node-png').PNG;
+let PNG = require('pngjs').PNG;
 let config = require('../configs/epsonConfig');
 
 let buffer = null;

--- a/lib/star.js
+++ b/lib/star.js
@@ -1,5 +1,5 @@
 let fs = require('fs');
-let PNG = require('node-png').PNG;
+let PNG = require('pngjs').PNG;
 let config = require('../configs/starConfig');
 
 let buffer = null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,6 +2,7 @@
   "name": "node-thermal-printer",
   "version": "1.1.1",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "dank-do-while": {
       "version": "https://registry.npmjs.org/dank-do-while/-/dank-do-while-0.1.2.tgz",
@@ -11,9 +12,10 @@
       "version": "https://registry.npmjs.org/net/-/net-1.0.2.tgz",
       "integrity": "sha1-0XV+yaf7I3HYPPR1XOPifhCCk4g="
     },
-    "node-png": {
-      "version": "https://registry.npmjs.org/node-png/-/node-png-0.4.3.tgz",
-      "integrity": "sha1-RQIjeWuC08yg/+Sl1cf6l0hZdOc="
+    "pngjs": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.3.0.tgz",
+      "integrity": "sha1-H1cwwYnJSTO4G+2iqy+OKFUmOo8="
     },
     "unorm": {
       "version": "https://registry.npmjs.org/unorm/-/unorm-1.4.1.tgz",
@@ -21,7 +23,10 @@
     },
     "write-file-queue": {
       "version": "https://registry.npmjs.org/write-file-queue/-/write-file-queue-0.0.1.tgz",
-      "integrity": "sha1-N2T2FEUYBulhLJabdw2DCmqBFek="
+      "integrity": "sha1-N2T2FEUYBulhLJabdw2DCmqBFek=",
+      "requires": {
+        "dank-do-while": "https://registry.npmjs.org/dank-do-while/-/dank-do-while-0.1.2.tgz"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/Klemen1337/node-thermal-printer",
   "dependencies": {
     "net": "^1.0.2",
-    "node-png": "^0.4.3",
+    "pngjs": "^3.2.0",
     "unorm": "^1.4.1",
     "write-file-queue": "0.0.1"
   }


### PR DESCRIPTION
node-png isn't updated for 3 years and depends on engine node 0.10.
Therefore yarn doesn't install it.
pngjs is compatible (forked from node-png) and much more stable/tested.