### PR TITLE
Remove Electron-Printer

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ print.getWidth();                                   // Get number of characters 
 
 ### Interace options
 - `tcp://192.168.0.99:9100` - network printer with port
-- `printer:auto` - auto select raw system printer via [Printer](https://www.npmjs.com/package/printer) or [Electron printer](https://www.npmjs.com/package/electron-printer) module
-- `printer:My Printer Name` - select system printer by name via [Printer](https://www.npmjs.com/package/printer) or [Electron printer](https://www.npmjs.com/package/electron-printer) module module
+- `printer:auto` - auto select raw system printer via [Printer](https://www.npmjs.com/package/printer) module
+- `printer:My Printer Name` - select system printer by name via [Printer](https://www.npmjs.com/package/printer) module
 - `\\.\COM1` - print via local port or file
 
 

--- a/interfaces/printer.js
+++ b/interfaces/printer.js
@@ -1,11 +1,9 @@
-const electron = typeof process !== 'undefined' && process.versions && !!process.versions.electron;
-
 function PrinterIface(printerName, moduleName) {
   this.name = printerName;
   if (moduleName && typeof moduleName === "object") {
     this.driver = moduleName;
   } else {
-    this.driver = require(moduleName || (electron ? "electron-printer" : "printer"));
+    this.driver = require(moduleName || "printer");
   }
 }
 

--- a/lib/core.js
+++ b/lib/core.js
@@ -55,14 +55,12 @@ module.exports = {
 
   cut: function(){
     append(config.CTL_VT);
-    append(config.CTL_VT);
     append(config.PAPER_FULL_CUT);
     append(config.HW_INIT);
   },
 
 
   partialCut: function(){
-    append(config.CTL_VT);
     append(config.CTL_VT);
     append(config.PAPER_PART_CUT);
     append(config.HW_INIT);


### PR DESCRIPTION
Remove Electron printer as it is unneeded as the normal Printer package works with electron after running electron rebuild, and works properly

