### PR TITLE
Add setBuffer() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ printer.printImage('./assets/olaii-logo-black.png', function(done){ }); // Print
 print.clear();                                      // Clears printText value
 print.getText();                                    // Returns printer buffer string value
 print.getBuffer();                                  // Returns printer buffer
+print.setBuffer(newBuffer);                         // Set the printer buffer to a copy of newBuffer
 print.getWidth();                                   // Get number of characters in one line
 ```
 

--- a/lib/core.js
+++ b/lib/core.js
@@ -91,6 +91,9 @@ module.exports = {
     return buffer;
   },
 
+  setBuffer: function(newBuffer){
+    buffer = Buffer.from(newBuffer);
+  },
 
   clear: function(){
     buffer = null;


### PR DESCRIPTION
Very simple addition I've had lying around for a while.

Needed a way to prepare multiple buffers in memory ahead of time and print them on demand. So I added a `setBuffer()` function to allow for that.

Debated whether it was "safe" to expose a `setBuffer()` function, but given that the `getBuffer()` function already returns a reference to the "private" buffer instance, which you can then mess around with, there's not much difference in simply replacing the buffer outright.