### PR TITLE
Add support for another charset

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -4,6 +4,7 @@ var fs = require('fs'),
     star = require('./star'),
     epson = require('./epson'),
     getInterface = require("../interfaces");
+    encoding = require('encoding')
 
 var printerTypes = {
   EPSON: 'epson',
@@ -104,17 +105,14 @@ module.exports = {
     append(buffer);
   },
 
-
-  print: function(text){
-    append(text.toString());
+  print: function(text, charset='UTF-8') {
+    append(encoding.convert(text, charset));
   },
 
-
-  println: function(text){
-    append(text.toString());
+  println: function(text, charset='UTF-8') {
+    append(encoding.convert(text, charset));
     append("\n");
   },
-
 
   printVerticalTab: function(){
     append(config.CTL_VT);

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/Klemen1337/node-thermal-printer",
   "dependencies": {
+    "encoding": "^0.1.12",
     "net": "^1.0.2",
     "pngjs": "^3.2.0",
     "unorm": "^1.4.1",


### PR DESCRIPTION
Hello I'm come from thailand. I wish to use this library with our project. but The problem is it can't using Thai language directly inside nodejs. so I edit some code for support multiple language.
You can use another language by using `printer.println('สวัสดีครับ', 'TIS-620')`.
I have tested with Epson TM-T81.