### PR TITLE
Don't bother the user anymore with code pages - accept UTF-8 and print it

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+# EditorConfig http://EditorConfig.org
+# https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+max_line_length = 150
+
+[*.{js,json,html}]
+# Set default charset
+charset = utf-8
+indent_style = space
+indent_size = 2
+
+# Domain-Specific Properties
+# Not implemented in all plugins.
+quote_type = single
+curly_bracket_next_line = false
+spaces_around_operators = false
+indent_brace_style = K&R
+continuation_indent_size = 8

--- a/configs/epsonConfig.js
+++ b/configs/epsonConfig.js
@@ -61,6 +61,42 @@ module.exports = {
     CHARCODE_VIETNAM    : new Buffer([0x1b, 0x52, 0x10]), // Vietnam
     CHARCODE_ARABIA     : new Buffer([0x1b, 0x52, 0x11]), // ARABIA
 
+    // Character code pages / iconv name of code table.
+    // Only code pages supported by iconv-lite are supported:
+    // https://github.com/ashtuchkin/iconv-lite/wiki/Supported-Encodings
+    CODE_PAGES: {
+        PC437_USA           : [Buffer.from([0x1b, 0x74, 0]), 'CP437'],
+        PC850_MULTILINGUAL  : [Buffer.from([0x1b, 0x74, 2]), 'CP850'],
+        PC860_PORTUGUESE    : [Buffer.from([0x1b, 0x74, 3]), 'CP860'],
+        PC863_CANADIAN_FRENCH : [Buffer.from([0x1b, 0x74, 4]), 'CP863'],
+        PC865_NORDIC        : [Buffer.from([0x1b, 0x74, 4]), 'CP865'],
+        PC851_GREEK         : [Buffer.from([0x1b, 0x74, 11]), 'CP860'],
+        // PC853_TURKISH       : [Buffer.from([0x1b, 0x74, 12]), 'CP853'],
+        PC857_TURKISH       : [Buffer.from([0x1b, 0x74, 13]), 'CP857'],
+        PC737_GREEK         : [Buffer.from([0x1b, 0x74, 14]), 'CP737'],
+        ISO8859_7_GREEK     : [Buffer.from([0x1b, 0x74, 15]), 'ISO-8859-7'],
+        WPC1252             : [Buffer.from([0x1b, 0x74, 16]), 'CP1252'],
+        PC866_CYRILLIC2     : [Buffer.from([0x1b, 0x74, 17]), 'CP866'],
+        PC852_LATIN2        : [Buffer.from([0x1b, 0x74, 18]), 'CP852'],
+        PC858_EURO          : [Buffer.from([0x1b, 0x74, 19]), 'CP858'],
+        WPC775_BALTIC_RIM   : [Buffer.from([0x1b, 0x74, 33]), 'CP775'],
+        PC855_CYRILLIC      : [Buffer.from([0x1b, 0x74, 34]), 'CP855'],
+        PC861_ICELANDIC     : [Buffer.from([0x1b, 0x74, 35]), 'CP861'],
+        PC862_HEBREW        : [Buffer.from([0x1b, 0x74, 36]), 'CP862'],
+        PC864_ARABIC        : [Buffer.from([0x1b, 0x74, 37]), 'CP864'],
+        PC869_GREEK         : [Buffer.from([0x1b, 0x74, 38]), 'CP869'],
+        ISO8859_2_LATIN2    : [Buffer.from([0x1b, 0x74, 39]), 'ISO-8859-2'],
+        ISO8859_15_LATIN9   : [Buffer.from([0x1b, 0x74, 40]), 'ISO-8859-15'],
+        PC1125_UKRANIAN     : [Buffer.from([0x1b, 0x74, 44]), 'CP1125'],
+        WPC1250_LATIN2      : [Buffer.from([0x1b, 0x74, 45]), 'WIN1250'],
+        WPC1251_CYRILLIC    : [Buffer.from([0x1b, 0x74, 46]), 'WIN1251'],
+        WPC1253_GREEK       : [Buffer.from([0x1b, 0x74, 47]), 'WIN1253'],
+        WPC1254_TURKISH     : [Buffer.from([0x1b, 0x74, 48]), 'WIN1254'],
+        WPC1255_HEBREW      : [Buffer.from([0x1b, 0x74, 49]), 'WIN1255'],
+        WPC1256_ARABIC      : [Buffer.from([0x1b, 0x74, 50]), 'WIN1256'],
+        WPC1257_BALTIC_RIM  : [Buffer.from([0x1b, 0x74, 51]), 'WIN1257'],
+        WPC1258_VIETNAMESE  : [Buffer.from([0x1b, 0x74, 52]), 'WIN1258']
+    },
 
     // Barcode format
     BARCODE_TXT_OFF : new Buffer([0x1d, 0x48, 0x00]), // HRI barcode chars OFF
@@ -139,26 +175,4 @@ module.exports = {
     PD_P50          : new Buffer([0x1d, 0x7c, 0x08]), // Printing Density +50%
     PD_P37          : new Buffer([0x1d, 0x7c, 0x07]), // Printing Density +37.5%
     PD_P25          : new Buffer([0x1d, 0x7c, 0x06]), // Printing Density +25%
-
-    specialCharacters: {
-      "Č": 94,
-      "č": 126,
-      "Š": 91,
-      "š": 123,
-      "Ž": 64,
-      "ž": 96,
-      "Đ": 92,
-      "đ": 124,
-      "Ć": 93,
-      "ć": 125,
-      "ß": 225,
-      "ẞ": 225,
-      "ö": 148,
-      "Ö": 153,
-      "Ä": 142,
-      "ä": 132,
-      "ü": 129,
-      "Ü": 154,
-      "é": 130
-    }
-}
+};

--- a/configs/epsonConfig.js
+++ b/configs/epsonConfig.js
@@ -41,61 +41,85 @@ module.exports = {
     TXT_ALIGN_CT    : new Buffer([0x1b, 0x61, 0x01]), // Centering
     TXT_ALIGN_RT    : new Buffer([0x1b, 0x61, 0x02]), // Right justification
 
-    // Char code table
-    CHARCODE_USA        : new Buffer([0x1b, 0x52, 0x00]), // USA
-    CHARCODE_FRANCE     : new Buffer([0x1b, 0x52, 0x01]), // France
-    CHARCODE_GERMANY    : new Buffer([0x1b, 0x52, 0x02]), // Germany
-    CHARCODE_UK         : new Buffer([0x1b, 0x52, 0x03]), // U.K.
-    CHARCODE_DENMARK1   : new Buffer([0x1b, 0x52, 0x04]), // Denmark I
-    CHARCODE_SWEDEN     : new Buffer([0x1b, 0x52, 0x05]), // Sweden
-    CHARCODE_ITALY      : new Buffer([0x1b, 0x52, 0x06]), // Italy
-    CHARCODE_SPAIN1     : new Buffer([0x1b, 0x52, 0x07]), // Spain I
-    CHARCODE_JAPAN      : new Buffer([0x1b, 0x52, 0x08]), // Japan
-    CHARCODE_NORWAY     : new Buffer([0x1b, 0x52, 0x09]), // Norway
-    CHARCODE_DENMARK2   : new Buffer([0x1b, 0x52, 0x0A]), // Denmark II
-    CHARCODE_SPAIN2     : new Buffer([0x1b, 0x52, 0x0B]), // Spain II
-    CHARCODE_LATINA     : new Buffer([0x1b, 0x52, 0x0C]), // Latin America
-    CHARCODE_KOREA      : new Buffer([0x1b, 0x52, 0x0D]), // Korea
-    CHARCODE_SLOVENIA   : new Buffer([0x1b, 0x52, 0x0E]), // Slovenia
-    CHARCODE_CHINA      : new Buffer([0x1b, 0x52, 0x0F]), // China
-    CHARCODE_VIETNAM    : new Buffer([0x1b, 0x52, 0x10]), // Vietnam
-    CHARCODE_ARABIA     : new Buffer([0x1b, 0x52, 0x11]), // ARABIA
+    // All code pages supported by printer.
+    CODE_PAGE_PC437_USA           : Buffer.from([0x1b, 0x74, 0]),
+    CODE_PAGE_KATAKANA            : Buffer.from([0x1b, 0x74, 1]),
+    CODE_PAGE_PC850_MULTILINGUAL  : Buffer.from([0x1b, 0x74, 2]),
+    CODE_PAGE_PC860_PORTUGUESE    : Buffer.from([0x1b, 0x74, 3]),
+    CODE_PAGE_PC863_CANADIAN_FRENCH : Buffer.from([0x1b, 0x74, 4]),
+    CODE_PAGE_PC865_NORDIC        : Buffer.from([0x1b, 0x74, 5]),
+    CODE_PAGE_PC851_GREEK         : Buffer.from([0x1b, 0x74, 11]),
+    CODE_PAGE_PC853_TURKISH       : Buffer.from([0x1b, 0x74, 12]),
+    CODE_PAGE_PC857_TURKISH       : Buffer.from([0x1b, 0x74, 13]),
+    CODE_PAGE_PC737_GREEK         : Buffer.from([0x1b, 0x74, 14]),
+    CODE_PAGE_ISO8859_7_GREEK     : Buffer.from([0x1b, 0x74, 15]),
+    CODE_PAGE_WPC1252             : Buffer.from([0x1b, 0x74, 16]),
+    CODE_PAGE_PC866_CYRILLIC2     : Buffer.from([0x1b, 0x74, 17]),
+    CODE_PAGE_PC852_LATIN2        : Buffer.from([0x1b, 0x74, 18]),
+    CODE_PAGE_PC858_EURO          : Buffer.from([0x1b, 0x74, 19]),
+    CODE_PAGE_KU42_THAI           : Buffer.from([0x1b, 0x74, 20]),
+    CODE_PAGE_TIS11_THAI          : Buffer.from([0x1b, 0x74, 21]),
+    CODE_PAGE_TIS18_THAI          : Buffer.from([0x1b, 0x74, 26]),
+    CODE_PAGE_TCVN3_VIETNAMESE_L  : Buffer.from([0x1b, 0x74, 30]),
+    CODE_PAGE_TCVN3_VIETNAMESE_U  : Buffer.from([0x1b, 0x74, 31]),
+    CODE_PAGE_PC720_ARABIC        : Buffer.from([0x1b, 0x74, 32]),
+    CODE_PAGE_WPC775_BALTIC_RIM   : Buffer.from([0x1b, 0x74, 33]),
+    CODE_PAGE_PC855_CYRILLIC      : Buffer.from([0x1b, 0x74, 34]),
+    CODE_PAGE_PC861_ICELANDIC     : Buffer.from([0x1b, 0x74, 35]),
+    CODE_PAGE_PC862_HEBREW        : Buffer.from([0x1b, 0x74, 36]),
+    CODE_PAGE_PC864_ARABIC        : Buffer.from([0x1b, 0x74, 37]),
+    CODE_PAGE_PC869_GREEK         : Buffer.from([0x1b, 0x74, 38]),
+    CODE_PAGE_ISO8859_2_LATIN2    : Buffer.from([0x1b, 0x74, 39]),
+    CODE_PAGE_ISO8859_15_LATIN9   : Buffer.from([0x1b, 0x74, 40]),
+    CODE_PAGE_PC1098_FARCI        : Buffer.from([0x1b, 0x74, 41]),
+    CODE_PAGE_PC1118_LITHUANIAN   : Buffer.from([0x1b, 0x74, 42]),
+    CODE_PAGE_PC1119_LITHUANIAN   : Buffer.from([0x1b, 0x74, 43]),
+    CODE_PAGE_PC1125_UKRANIAN     : Buffer.from([0x1b, 0x74, 44]),
+    CODE_PAGE_WPC1250_LATIN2      : Buffer.from([0x1b, 0x74, 45]),
+    CODE_PAGE_WPC1251_CYRILLIC    : Buffer.from([0x1b, 0x74, 46]),
+    CODE_PAGE_WPC1253_GREEK       : Buffer.from([0x1b, 0x74, 47]),
+    CODE_PAGE_WPC1254_TURKISH     : Buffer.from([0x1b, 0x74, 48]),
+    CODE_PAGE_WPC1255_HEBREW      : Buffer.from([0x1b, 0x74, 49]),
+    CODE_PAGE_WPC1256_ARABIC      : Buffer.from([0x1b, 0x74, 50]),
+    CODE_PAGE_WPC1257_BALTIC_RIM  : Buffer.from([0x1b, 0x74, 51]),
+    CODE_PAGE_WPC1258_VIETNAMESE  : Buffer.from([0x1b, 0x74, 52]),
+    CODE_PAGE_KZ1048_KAZAKHSTAN   : Buffer.from([0x1b, 0x74, 53]),
 
     // Character code pages / iconv name of code table.
-    // Only code pages supported by iconv-lite are supported:
+    // Only code pages supported by iconv-lite:
     // https://github.com/ashtuchkin/iconv-lite/wiki/Supported-Encodings
     CODE_PAGES: {
-        PC437_USA           : [Buffer.from([0x1b, 0x74, 0]), 'CP437'],
-        PC850_MULTILINGUAL  : [Buffer.from([0x1b, 0x74, 2]), 'CP850'],
-        PC860_PORTUGUESE    : [Buffer.from([0x1b, 0x74, 3]), 'CP860'],
-        PC863_CANADIAN_FRENCH : [Buffer.from([0x1b, 0x74, 4]), 'CP863'],
-        PC865_NORDIC        : [Buffer.from([0x1b, 0x74, 4]), 'CP865'],
-        PC851_GREEK         : [Buffer.from([0x1b, 0x74, 11]), 'CP860'],
-        // PC853_TURKISH       : [Buffer.from([0x1b, 0x74, 12]), 'CP853'],
-        PC857_TURKISH       : [Buffer.from([0x1b, 0x74, 13]), 'CP857'],
-        PC737_GREEK         : [Buffer.from([0x1b, 0x74, 14]), 'CP737'],
-        ISO8859_7_GREEK     : [Buffer.from([0x1b, 0x74, 15]), 'ISO-8859-7'],
-        WPC1252             : [Buffer.from([0x1b, 0x74, 16]), 'CP1252'],
-        PC866_CYRILLIC2     : [Buffer.from([0x1b, 0x74, 17]), 'CP866'],
-        PC852_LATIN2        : [Buffer.from([0x1b, 0x74, 18]), 'CP852'],
-        PC858_EURO          : [Buffer.from([0x1b, 0x74, 19]), 'CP858'],
-        WPC775_BALTIC_RIM   : [Buffer.from([0x1b, 0x74, 33]), 'CP775'],
-        PC855_CYRILLIC      : [Buffer.from([0x1b, 0x74, 34]), 'CP855'],
-        PC861_ICELANDIC     : [Buffer.from([0x1b, 0x74, 35]), 'CP861'],
-        PC862_HEBREW        : [Buffer.from([0x1b, 0x74, 36]), 'CP862'],
-        PC864_ARABIC        : [Buffer.from([0x1b, 0x74, 37]), 'CP864'],
-        PC869_GREEK         : [Buffer.from([0x1b, 0x74, 38]), 'CP869'],
-        ISO8859_2_LATIN2    : [Buffer.from([0x1b, 0x74, 39]), 'ISO-8859-2'],
-        ISO8859_15_LATIN9   : [Buffer.from([0x1b, 0x74, 40]), 'ISO-8859-15'],
-        PC1125_UKRANIAN     : [Buffer.from([0x1b, 0x74, 44]), 'CP1125'],
-        WPC1250_LATIN2      : [Buffer.from([0x1b, 0x74, 45]), 'WIN1250'],
-        WPC1251_CYRILLIC    : [Buffer.from([0x1b, 0x74, 46]), 'WIN1251'],
-        WPC1253_GREEK       : [Buffer.from([0x1b, 0x74, 47]), 'WIN1253'],
-        WPC1254_TURKISH     : [Buffer.from([0x1b, 0x74, 48]), 'WIN1254'],
-        WPC1255_HEBREW      : [Buffer.from([0x1b, 0x74, 49]), 'WIN1255'],
-        WPC1256_ARABIC      : [Buffer.from([0x1b, 0x74, 50]), 'WIN1256'],
-        WPC1257_BALTIC_RIM  : [Buffer.from([0x1b, 0x74, 51]), 'WIN1257'],
-        WPC1258_VIETNAMESE  : [Buffer.from([0x1b, 0x74, 52]), 'WIN1258']
+      PC437_USA             : 'CP437',
+      PC850_MULTILINGUAL    : 'CP850',
+      PC860_PORTUGUESE      : 'CP860',
+      PC863_CANADIAN_FRENCH : 'CP863',
+      PC865_NORDIC          : 'CP865',
+      PC851_GREEK           : 'CP860',
+      PC857_TURKISH         : 'CP857',
+      PC737_GREEK           : 'CP737',
+      ISO8859_7_GREEK       : 'ISO-8859-7',
+      WPC1252               : 'CP1252',
+      PC866_CYRILLIC2       : 'CP866',
+      PC852_LATIN2          : 'CP852',
+      PC858_EURO            : 'CP858',
+      WPC775_BALTIC_RIM     : 'CP775',
+      PC855_CYRILLIC        : 'CP855',
+      PC861_ICELANDIC       : 'CP861',
+      PC862_HEBREW          : 'CP862',
+      PC864_ARABIC          : 'CP864',
+      PC869_GREEK           : 'CP869',
+      ISO8859_2_LATIN2      : 'ISO-8859-2',
+      ISO8859_15_LATIN9     : 'ISO-8859-15',
+      PC1125_UKRANIAN       : 'CP1125',
+      WPC1250_LATIN2        : 'WIN1250',
+      WPC1251_CYRILLIC      : 'WIN1251',
+      WPC1253_GREEK         : 'WIN1253',
+      WPC1254_TURKISH       : 'WIN1254',
+      WPC1255_HEBREW        : 'WIN1255',
+      WPC1256_ARABIC        : 'WIN1256',
+      WPC1257_BALTIC_RIM    : 'WIN1257',
+      WPC1258_VIETNAMESE    : 'WIN1258',
+      KZ1048_KAZAKHSTAN     : 'RK1048'
     },
 
     // Barcode format

--- a/configs/starConfig.js
+++ b/configs/starConfig.js
@@ -62,6 +62,13 @@ module.exports = {
     CHARCODE_THAI17 : new Buffer([0x1b, 0x1d, 0x74, 0x65]), // Thai character code 17
     CHARCODE_THAI18 : new Buffer([0x1b, 0x1d, 0x74, 0x66]), // Thai character code 18
 
+    // Character code pages / iconv name of code table.
+    // Only code pages supported by iconv-lite are supported:
+    // https://github.com/ashtuchkin/iconv-lite/wiki/Supported-Encodings
+    CODE_PAGES: {
+        // TODO
+    },
+
     // Barcode format
     BARCODE_TXT_OFF : new Buffer([0x1d, 0x48, 0x00]), // HRI barcode chars OFF
     BARCODE_TXT_ABV : new Buffer([0x1d, 0x48, 0x01]), // HRI barcode chars above
@@ -127,26 +134,4 @@ module.exports = {
     PD_P50          : new Buffer([0x1d, 0x7c, 0x08]), // Printing Density +50%
     PD_P37          : new Buffer([0x1d, 0x7c, 0x07]), // Printing Density +37.5%
     PD_P25          : new Buffer([0x1d, 0x7c, 0x06]), // Printing Density +25%
-
-    specialCharacters: {
-      "Č": 172,
-      "č": 159,
-      "Š": 230,
-      "š": 231,
-      "Ž": 166,
-      "ž": 167,
-      "Đ": 209,
-      "đ": 208,
-      "Ć": 143,
-      "ć": 134,
-      "ß": 225,
-      "ẞ": 225,
-      "ö": 148,
-      "Ö": 153,
-      "Ä": 142,
-      "ä": 132,
-      "ü": 129,
-      "Ü": 154,
-      "é": 130
-    }
-}
+};

--- a/configs/starConfig.js
+++ b/configs/starConfig.js
@@ -42,31 +42,85 @@ module.exports = {
     TXT_ALIGN_CT    : new Buffer([0x1b, 0x1d, 0x61, 0x01]), // Centering
     TXT_ALIGN_RT    : new Buffer([0x1b, 0x1d, 0x61, 0x02]), // Right justification
 
-    // Char code table
-    CHARCODE_PC437  : new Buffer([0x1b, 0x1d, 0x74, 0x00]), // USA: Standard Europe
-    CHARCODE_JIS    : new Buffer([0x1b, 0x1d, 0x74, 0x02]), // Japanese Katakana
-    CHARCODE_PC858  : new Buffer([0x1b, 0x1d, 0x74, 0x04]), // Multilingual
-    CHARCODE_PC860  : new Buffer([0x1b, 0x1d, 0x74, 0x06]), // Portuguese
-    CHARCODE_PC863  : new Buffer([0x1b, 0x1d, 0x74, 0x08]), // Canadian-French
-    CHARCODE_PC865  : new Buffer([0x1b, 0x1d, 0x74, 0x09]), // Nordic
-    CHARCODE_GREEK  : new Buffer([0x1b, 0x1d, 0x74, 0x0f]), // Greek
-    CHARCODE_HEBREW : new Buffer([0x1b, 0x1d, 0x74, 0x0d]), // Hebrew
-    CHARCODE_PC1252 : new Buffer([0x1b, 0x1d, 0x74, 0x20]), // Western European Windows Code Set
-    CHARCODE_PC866  : new Buffer([0x1b, 0x1d, 0x74, 0x0a]), // Cirillic //2
-    CHARCODE_PC852  : new Buffer([0x1b, 0x1d, 0x74, 0x05]), // Latin 2
-    CHARCODE_THAI42 : new Buffer([0x1b, 0x1d, 0x74, 0x60]), // Thai character code 42
-    CHARCODE_THAI11 : new Buffer([0x1b, 0x1d, 0x74, 0x61]), // Thai character code 11
-    CHARCODE_THAI13 : new Buffer([0x1b, 0x1d, 0x74, 0x62]), // Thai character code 13
-    CHARCODE_THAI14 : new Buffer([0x1b, 0x1d, 0x74, 0x63]), // Thai character code 14
-    CHARCODE_THAI16 : new Buffer([0x1b, 0x1d, 0x74, 0x64]), // Thai character code 16
-    CHARCODE_THAI17 : new Buffer([0x1b, 0x1d, 0x74, 0x65]), // Thai character code 17
-    CHARCODE_THAI18 : new Buffer([0x1b, 0x1d, 0x74, 0x66]), // Thai character code 18
+    // All code pages supported by printer.
+    CODE_PAGE_PC437_USA           : Buffer.from([0x1b, 0x74, 0]),
+    CODE_PAGE_KATAKANA            : Buffer.from([0x1b, 0x74, 1]),
+    CODE_PAGE_PC850_MULTILINGUAL  : Buffer.from([0x1b, 0x74, 2]),
+    CODE_PAGE_PC860_PORTUGUESE    : Buffer.from([0x1b, 0x74, 3]),
+    CODE_PAGE_PC863_CANADIAN_FRENCH : Buffer.from([0x1b, 0x74, 4]),
+    CODE_PAGE_PC865_NORDIC        : Buffer.from([0x1b, 0x74, 5]),
+    CODE_PAGE_PC851_GREEK         : Buffer.from([0x1b, 0x74, 11]),
+    CODE_PAGE_PC853_TURKISH       : Buffer.from([0x1b, 0x74, 12]),
+    CODE_PAGE_PC857_TURKISH       : Buffer.from([0x1b, 0x74, 13]),
+    CODE_PAGE_PC737_GREEK         : Buffer.from([0x1b, 0x74, 14]),
+    CODE_PAGE_ISO8859_7_GREEK     : Buffer.from([0x1b, 0x74, 15]),
+    CODE_PAGE_WPC1252             : Buffer.from([0x1b, 0x74, 16]),
+    CODE_PAGE_PC866_CYRILLIC2     : Buffer.from([0x1b, 0x74, 17]),
+    CODE_PAGE_PC852_LATIN2        : Buffer.from([0x1b, 0x74, 18]),
+    CODE_PAGE_PC858_EURO          : Buffer.from([0x1b, 0x74, 19]),
+    CODE_PAGE_KU42_THAI           : Buffer.from([0x1b, 0x74, 20]),
+    CODE_PAGE_TIS11_THAI          : Buffer.from([0x1b, 0x74, 21]),
+    CODE_PAGE_TIS18_THAI          : Buffer.from([0x1b, 0x74, 26]),
+    CODE_PAGE_TCVN3_VIETNAMESE_L  : Buffer.from([0x1b, 0x74, 30]),
+    CODE_PAGE_TCVN3_VIETNAMESE_U  : Buffer.from([0x1b, 0x74, 31]),
+    CODE_PAGE_PC720_ARABIC        : Buffer.from([0x1b, 0x74, 32]),
+    CODE_PAGE_WPC775_BALTIC_RIM   : Buffer.from([0x1b, 0x74, 33]),
+    CODE_PAGE_PC855_CYRILLIC      : Buffer.from([0x1b, 0x74, 34]),
+    CODE_PAGE_PC861_ICELANDIC     : Buffer.from([0x1b, 0x74, 35]),
+    CODE_PAGE_PC862_HEBREW        : Buffer.from([0x1b, 0x74, 36]),
+    CODE_PAGE_PC864_ARABIC        : Buffer.from([0x1b, 0x74, 37]),
+    CODE_PAGE_PC869_GREEK         : Buffer.from([0x1b, 0x74, 38]),
+    CODE_PAGE_ISO8859_2_LATIN2    : Buffer.from([0x1b, 0x74, 39]),
+    CODE_PAGE_ISO8859_15_LATIN9   : Buffer.from([0x1b, 0x74, 40]),
+    CODE_PAGE_PC1098_FARCI        : Buffer.from([0x1b, 0x74, 41]),
+    CODE_PAGE_PC1118_LITHUANIAN   : Buffer.from([0x1b, 0x74, 42]),
+    CODE_PAGE_PC1119_LITHUANIAN   : Buffer.from([0x1b, 0x74, 43]),
+    CODE_PAGE_PC1125_UKRANIAN     : Buffer.from([0x1b, 0x74, 44]),
+    CODE_PAGE_WPC1250_LATIN2      : Buffer.from([0x1b, 0x74, 45]),
+    CODE_PAGE_WPC1251_CYRILLIC    : Buffer.from([0x1b, 0x74, 46]),
+    CODE_PAGE_WPC1253_GREEK       : Buffer.from([0x1b, 0x74, 47]),
+    CODE_PAGE_WPC1254_TURKISH     : Buffer.from([0x1b, 0x74, 48]),
+    CODE_PAGE_WPC1255_HEBREW      : Buffer.from([0x1b, 0x74, 49]),
+    CODE_PAGE_WPC1256_ARABIC      : Buffer.from([0x1b, 0x74, 50]),
+    CODE_PAGE_WPC1257_BALTIC_RIM  : Buffer.from([0x1b, 0x74, 51]),
+    CODE_PAGE_WPC1258_VIETNAMESE  : Buffer.from([0x1b, 0x74, 52]),
+    CODE_PAGE_KZ1048_KAZAKHSTAN   : Buffer.from([0x1b, 0x74, 53]),
 
     // Character code pages / iconv name of code table.
-    // Only code pages supported by iconv-lite are supported:
+    // Only code pages supported by iconv-lite:
     // https://github.com/ashtuchkin/iconv-lite/wiki/Supported-Encodings
     CODE_PAGES: {
-        // TODO
+      PC437_USA             : 'CP437',
+      PC850_MULTILINGUAL    : 'CP850',
+      PC860_PORTUGUESE      : 'CP860',
+      PC863_CANADIAN_FRENCH : 'CP863',
+      PC865_NORDIC          : 'CP865',
+      PC851_GREEK           : 'CP860',
+      PC857_TURKISH         : 'CP857',
+      PC737_GREEK           : 'CP737',
+      ISO8859_7_GREEK       : 'ISO-8859-7',
+      WPC1252               : 'CP1252',
+      PC866_CYRILLIC2       : 'CP866',
+      PC852_LATIN2          : 'CP852',
+      PC858_EURO            : 'CP858',
+      WPC775_BALTIC_RIM     : 'CP775',
+      PC855_CYRILLIC        : 'CP855',
+      PC861_ICELANDIC       : 'CP861',
+      PC862_HEBREW          : 'CP862',
+      PC864_ARABIC          : 'CP864',
+      PC869_GREEK           : 'CP869',
+      ISO8859_2_LATIN2      : 'ISO-8859-2',
+      ISO8859_15_LATIN9     : 'ISO-8859-15',
+      PC1125_UKRANIAN       : 'CP1125',
+      WPC1250_LATIN2        : 'WIN1250',
+      WPC1251_CYRILLIC      : 'WIN1251',
+      WPC1253_GREEK         : 'WIN1253',
+      WPC1254_TURKISH       : 'WIN1254',
+      WPC1255_HEBREW        : 'WIN1255',
+      WPC1256_ARABIC        : 'WIN1256',
+      WPC1257_BALTIC_RIM    : 'WIN1257',
+      WPC1258_VIETNAMESE    : 'WIN1258',
+      KZ1048_KAZAKHSTAN     : 'RK1048'
     },
 
     // Barcode format

--- a/examples/unicode.js
+++ b/examples/unicode.js
@@ -1,0 +1,16 @@
+const printer = require("../node-thermal-printer");
+
+printer.init({
+    type: printer.printerTypes.EPSON,
+    width: 42,
+    // interface: '/dev/usb/lp0',
+    interface: 'tcp://10.0.1.23:9100'
+});
+
+// Print the Euro currency sign and other non ASCII characters from an UTF-8 string.
+printer.println('Print special chars:\n€±‹›ČčŠšŽžĐđĆćßẞöÖÄäüÜé©®ΩضהψЖƒ');
+
+printer.newLine();
+printer.newLine();
+printer.cut();
+printer.execute();

--- a/interfaces/index.d.ts
+++ b/interfaces/index.d.ts
@@ -1,0 +1,36 @@
+export interface IPrinterConfig {
+
+    /**
+     * Printer brand, currently the only supported brands are Star and Epson.
+     * - star
+     * - epson
+     */
+    type: string,
+
+    /**
+     * The maximum number of characters the printer can print in one row (Font A).
+     */
+    width: number,
+
+    /**
+     * The interface to connect to; eg
+     * - /dev/usb/lp0
+     * - tcp://10.0.1.23:9100
+     */
+    interface: string,
+
+    /**
+     * @deprecated Replaced by iconv and unicode
+     */
+    characterSet?: string,
+
+    /**
+     * If true, it replaces special characters by ascii equivalent?
+     */
+    removeSpecialCharacters?: boolean,
+
+    /**
+     * If true, it replaces
+     */
+    replaceSpecialCharacters?: boolean
+}

--- a/interfaces/index.d.ts
+++ b/interfaces/index.d.ts
@@ -20,17 +20,7 @@ export interface IPrinterConfig {
     interface: string,
 
     /**
-     * @deprecated Replaced by iconv and unicode
-     */
-    characterSet?: string,
-
-    /**
-     * If true, it replaces special characters by ascii equivalent?
+     * If true, it replaces special characters by ascii equivalent.
      */
     removeSpecialCharacters?: boolean,
-
-    /**
-     * If true, it replaces
-     */
-    replaceSpecialCharacters?: boolean
 }

--- a/lib/core.js
+++ b/lib/core.js
@@ -20,505 +20,495 @@ var printerConfig;
 var codePage;
 
 module.exports = {
-    printerTypes: printerTypes,
-
-    /**
-     * Initialize printer.
-     *
-     * @param {IPrinterConfig} initConfig Configuration object
-     */
-    init: function (initConfig) {
-        if (initConfig.type === printerTypes.STAR) {
-            config = require('../configs/starConfig');
-        } else {
-            config = require('../configs/epsonConfig');
-        }
-
-        iface = getInterface(initConfig.interface);
-
-        if (!initConfig.width) initConfig.width = 48;
-        if (!initConfig.characterSet) initConfig.characterSet = "SLOVENIA";
-        if (initConfig.removeSpecialCharacters === undefined) initConfig.removeSpecialCharacters = false;
-
-        printerConfig = initConfig;
-
-        // Code page initially active.
-        codePage = 'PC437_USA';
-        buffer = Buffer.from(config.CODE_PAGES[codePage][0]);
-    },
-
-
-    execute: function (cb) {
-        iface.execute(buffer, function (err) {
-            if (!err) {
-                buffer = null;
-                if (typeof cb === "function") {
-                    cb(null);
-                }
-            } else {
-                if (typeof cb === "function") {
-                    cb(err);
-                }
-            }
-        });
-    },
-
-
-    cut: function () {
-        append(config.CTL_VT);
-        append(config.CTL_VT);
-        append(config.PAPER_FULL_CUT);
-        append(config.HW_INIT);
-    },
-
-
-    partialCut: function () {
-        append(config.CTL_VT);
-        append(config.CTL_VT);
-        append(config.PAPER_PART_CUT);
-        append(config.HW_INIT);
-    },
-
-
-    beep: function () {
-        if (printerConfig.type === printerTypes.STAR) {
-            console.error("Beep not supported on STAR yet!");
-        } else {
-            append(config.BEEP);
-        }
-    },
-
-    getWidth: function () {
-        return parseInt(printerConfig.width);
-    },
-
-
-    getText: function () {
-        return buffer.toString();
-    },
-
-
-    getBuffer: function () {
-        return buffer;
-    },
-
-    setBuffer: function (newBuffer) {
-        buffer = Buffer.from(newBuffer);
-    },
-
-    clear: function () {
-        buffer = null;
-    },
-
-
-    add: function (buffer) {
-        append(buffer);
-    },
-
-
-    print: function (text) {
-        append(text.toString());
-    },
-
-
-    println: function (text) {
-        append(text.toString());
-        append("\n");
-    },
-
-
-    printVerticalTab: function () {
-        append(config.CTL_VT);
-    },
-
-
-    bold: function (enabled) {
-        if (enabled) append(config.TXT_BOLD_ON);
-        else append(config.TXT_BOLD_OFF);
-    },
-
-
-    underline: function (enabled) {
-        if (enabled) append(config.TXT_UNDERL_ON);
-        else append(config.TXT_UNDERL_OFF);
-    },
-
-
-    underlineThick: function (enabled) {
-        if (enabled) append(config.TXT_UNDERL2_ON);
-        else append(config.TXT_UNDERL_OFF);
-    },
-
-
-    upsideDown: function (enabled) {
-        if (enabled) append(config.UPSIDE_DOWN_ON);
-        else append(config.UPSIDE_DOWN_OFF);
-    },
-
-
-    invert: function (enabled) {
-        if (enabled) append(config.TXT_INVERT_ON);
-        else append(config.TXT_INVERT_OFF);
-    },
-
-
-    openCashDrawer: function () {
-        if (printerConfig.type === printerTypes.STAR) {
-            append(config.CD_KICK);
-        } else {
-            append(config.CD_KICK_2);
-            append(config.CD_KICK_5);
-        }
-    },
-
-
-    alignCenter: function () {
-        append(config.TXT_ALIGN_CT);
-    },
-
-
-    alignLeft: function () {
-        append(config.TXT_ALIGN_LT);
-    },
-
-
-    alignRight: function () {
-        append(config.TXT_ALIGN_RT);
-    },
-
-
-    setTypeFontA: function () {
-        append(config.TXT_FONT_A);
-    },
-
-
-    setTypeFontB: function () {
-        append(config.TXT_FONT_B);
-    },
-
-
-    setTextNormal: function () {
-        append(config.TXT_NORMAL);
-    },
-
-
-    setTextDoubleHeight: function () {
-        append(config.TXT_2HEIGHT);
-    },
-
-
-    setTextDoubleWidth: function () {
-        append(config.TXT_2WIDTH);
-    },
-
-    setTextQuadArea: function () {
-        append(config.TXT_4SQUARE);
-    },
-
-
-    newLine: function () {
-        append(config.CTL_LF);
-    },
-
-
-    drawLine: function () {
-        // module.exports.newLine();
-        for (var i = 0; i < printerConfig.width; i++) {
-            if (printerConfig.lineChar) append(new Buffer(printerConfig.lineChar));
-            else append(new Buffer([196]));
-        }
-        module.exports.newLine();
-    },
-
-
-    leftRight: function (left, right) {
-        append(left.toString());
-        var width = printerConfig.width - left.toString().length - right.toString().length;
-        for (var i = 0; i < width; i++) {
-            append(new Buffer(" "));
-        }
-        append(right.toString());
-        module.exports.newLine();
-    },
-
-
-    table: function (data) {
-        var cellWidth = printerConfig.width / data.length;
-        for (var i = 0; i < data.length; i++) {
-            append(data[i].toString());
-            var spaces = cellWidth - data[i].toString().length;
-            for (var j = 0; j < spaces; j++) {
-                append(new Buffer(" "));
-            }
-        }
-        module.exports.newLine();
-    },
-
-
-    // Options: text, align, width, bold
-    tableCustom: function (data) {
-        var cellWidth = printerConfig.width / data.length;
-        var secondLine = [];
-        var secondLineEnabled = false;
-
-        for (var i = 0; i < data.length; i++) {
-            var tooLong = false;
-            var obj = data[i];
-            obj.text = obj.text.toString();
-
-            if (obj.width) cellWidth = printerConfig.width * obj.width;
-            if (obj.bold) module.exports.bold(true);
-
-            // If text is too wide go to next line
-            if (cellWidth < obj.text.length) {
-                tooLong = true;
-                obj.originalText = obj.text;
-                obj.text = obj.text.substring(0, cellWidth);
-            }
-
-            if (obj.align == "CENTER") {
-                var spaces = (cellWidth - obj.text.toString().length) / 2;
-                for (var j = 0; j < spaces; j++) {
-                    append(new Buffer(" "));
-                }
-                if (obj.text != '') append(obj.text);
-                for (var j = 0; j < spaces - 1; j++) {
-                    append(new Buffer(" "));
-                }
-
-            } else if (obj.align == "RIGHT") {
-                var spaces = cellWidth - obj.text.toString().length;
-                for (var j = 0; j < spaces; j++) {
-                    append(new Buffer(" "));
-                }
-                if (obj.text != '') append(obj.text);
-
-            } else {
-                if (obj.text != '') append(obj.text);
-                var spaces = cellWidth - obj.text.toString().length;
-                for (var j = 0; j < spaces; j++) {
-                    append(new Buffer(" "));
-                }
-
-            }
-
-            if (obj.bold) module.exports.bold(false);
-
-
-            if (tooLong) {
-                secondLineEnabled = true;
-                obj.text = obj.originalText.substring(cellWidth - 1);
-                secondLine.push(obj);
-            } else {
-                obj.text = "";
-                secondLine.push(obj);
-            }
-        }
-
-        module.exports.newLine();
-
-        // Print the second line
-        if (secondLineEnabled) {
-            module.exports.tableCustom(secondLine);
-        }
-    },
-
-
-    isPrinterConnected: function (exists) {
-        iface.isPrinterConnected(exists);
-    },
-
-
-    // ----------------------------------------------------- PRINT QR
-    // -----------------------------------------------------
-    printQR: function (str, settings) {
-        if (printerConfig.type === printerTypes.STAR) {
-            append(star.printQR(str, settings));
-        } else if (printerConfig.type === printerTypes.EPSON) {
-            append(epson.printQR(str, settings));
-        } else {
-            console.error("QR not supported on '" + printerConfig.type + "' yet!");
-        }
-    },
-
-
-    // ----------------------------------------------------- PRINT BARCODE
-    // -----------------------------------------------------
-    printBarcode: function (data, type, settings) {
-        if (printerConfig.type === printerTypes.EPSON) {
-            append(epson.printBarcode(data, type, settings));
-        } else {
-            console.error("Barcode not supported on '" + printerConfig.type + "' yet!");
-        }
-    },
-
-
-    // ----------------------------------------------------- PRINT MAXICODE
-    // -----------------------------------------------------
-    maxiCode: function (data, settings) {
-        if (printerConfig.type === printerTypes.EPSON) {
-            append(epson.maxiCode(data, settings));
-        } else {
-            console.error("MaxiCode not supported on '" + printerConfig.type + "' yet!");
-        }
-    },
-
-
-    // ----------------------------------------------------- PRINT CODE128
-    // -----------------------------------------------------
-    code128: function (data, settings) {
-        if (printerConfig.type === printerTypes.STAR) {
-            append(star.code128(data, settings));
-        } else {
-            console.error("Code128 not supported on '" + printerConfig.type + "' yet!");
-        }
-    },
-
-
-    // ----------------------------------------------------- PRINT PDF417
-    // -----------------------------------------------------
-    pdf417: function (data, settings) {
-        if (printerConfig.type === printerTypes.STAR) {
-            append(star.pdf417(data, settings));
-        } else if (printerConfig.type === printerTypes.EPSON) {
-            append(epson.pdf417(data, settings));
-        } else {
-            console.error("PDF417 not supported on '" + printerConfig.type + "' yet!");
-        }
-    },
-
-
-    // ----------------------------------------------------- PRINT IMAGE
-    // -----------------------------------------------------
-    printImage: function (image, callback) {
-        try {
-            // Check if file exists
-            fs.accessSync(image);
-
-            // Check for file type
-            if (image.slice(-4) === ".png") {
-                if (printerConfig.type === printerTypes.STAR) {
-                    star.printImageStar(image, function (response) {
-                        if (response) append(response);
-                        callback(response);
-                    });
-                } else if (printerConfig.type === printerTypes.EPSON) {
-                    epson.printImageEpson(image, function (response) {
-                        if (response) append(response);
-                        callback(response);
-                    });
-                } else {
-                    console.error("Image print not supported on '" + printerConfig.type + "' yet!");
-                }
-            } else {
-                console.error("Image printing supports only PNG files!");
-                callback(false);
-            }
-        } catch (e) {
-            callback(false);
-        }
-    },
-
-
-    // ----------------------------------------------------- PRINT IMAGE BUFFER
-    // -----------------------------------------------------
-    printImageBuffer: function (buffer, callback) {
-        var png = new PNG({
-            filterType: 4
-        }).parse(buffer);
-
-        png.on('parsed', function () {
-            if (printerConfig.type === printerTypes.STAR) {
-                star._printImageBufferStar(this.width, this.height, this.data, function (response) {
-                    if (response) append(response);
-                    callback(response);
-                });
-            } else {
-                epson._printImageBufferEpson(this.width, this.height, this.data, function (response) {
-                    if (response) append(response);
-                    callback(response);
-                });
-            }
-        });
-    },
-
-
-    // ------------------------------ RAW ------------------------------
-    raw: function (text, cb) {
-        iface.execute(text, function (err) {
-            if (!err) {
-                if (typeof cb === "function") {
-                    cb(null);
-                }
-            } else {
-                if (typeof cb === "function") {
-                    cb(err);
-                }
-            }
-        });
+  printerTypes: printerTypes,
+
+  /**
+   * Initialize printer.
+   *
+   * @param {IPrinterConfig} initConfig Configuration object
+   */
+  init: function (initConfig) {
+    if (initConfig.type === printerTypes.STAR) {
+      config = require('../configs/starConfig');
+    } else {
+      config = require('../configs/epsonConfig');
     }
+
+    iface = getInterface(initConfig.interface);
+
+    if (!initConfig.width) initConfig.width = 48;
+    if (!initConfig.characterSet) initConfig.characterSet = "SLOVENIA";
+    if (initConfig.removeSpecialCharacters === undefined) initConfig.removeSpecialCharacters = false;
+
+    printerConfig = initConfig;
+
+    // Code page initially active.
+    codePage = 'PC437_USA';
+    buffer = Buffer.from(config.CODE_PAGES[codePage][0]);
+  },
+
+
+  execute: function(cb){
+    iface.execute(buffer, function (err) {
+      if (!err) {
+        buffer = null;
+        if (typeof cb === "function") {
+          cb(null);
+        }
+      } else {
+        if (typeof cb === "function") {
+          cb(err);
+        }
+      }
+    });
+  },
+
+
+  cut: function(){
+    append(config.CTL_VT);
+    append(config.CTL_VT);
+    append(config.PAPER_FULL_CUT);
+    append(config.HW_INIT);
+  },
+
+
+  partialCut: function(){
+    append(config.CTL_VT);
+    append(config.CTL_VT);
+    append(config.PAPER_PART_CUT);
+    append(config.HW_INIT);
+  },
+
+
+  beep: function(){
+    if (printerConfig.type === printerTypes.STAR){
+      console.error("Beep not supported on STAR yet!");
+    } else {
+      append(config.BEEP);
+    }
+  },
+
+  getWidth: function(){
+    return parseInt(printerConfig.width);
+  },
+
+
+  getText: function(){
+    return buffer.toString();
+  },
+
+
+  getBuffer: function(){
+    return buffer;
+  },
+
+  setBuffer: function(newBuffer){
+    buffer = Buffer.from(newBuffer);
+  },
+
+  clear: function(){
+    buffer = null;
+  },
+
+
+  add: function(buffer){
+    append(buffer);
+  },
+
+
+  print: function(text){
+    append(text.toString());
+  },
+
+
+  println: function(text){
+    append(text.toString());
+    append("\n");
+  },
+
+
+  printVerticalTab: function(){
+    append(config.CTL_VT);
+  },
+
+
+  bold: function(enabled){
+    if(enabled) append(config.TXT_BOLD_ON);
+    else append(config.TXT_BOLD_OFF);
+  },
+
+
+  underline: function(enabled){
+    if(enabled) append(config.TXT_UNDERL_ON);
+    else append(config.TXT_UNDERL_OFF);
+  },
+
+
+  underlineThick: function(enabled){
+    if(enabled) append(config.TXT_UNDERL2_ON);
+    else append(config.TXT_UNDERL_OFF);
+  },
+
+
+  upsideDown: function(enabled){
+     if(enabled) append(config.UPSIDE_DOWN_ON);
+     else append(config.UPSIDE_DOWN_OFF);
+  },
+
+
+  invert: function(enabled){
+    if(enabled) append(config.TXT_INVERT_ON);
+    else append(config.TXT_INVERT_OFF);
+  },
+
+
+  openCashDrawer: function(){
+    if(printerConfig.type === printerTypes.STAR){
+      append(config.CD_KICK);
+    } else {
+      append(config.CD_KICK_2);
+      append(config.CD_KICK_5);
+    }
+  },
+
+
+  alignCenter: function (){
+    append(config.TXT_ALIGN_CT);
+  },
+
+
+  alignLeft: function (){
+    append(config.TXT_ALIGN_LT);
+  },
+
+
+  alignRight: function(){
+    append(config.TXT_ALIGN_RT);
+  },
+
+
+  setTypeFontA: function(){
+    append(config.TXT_FONT_A);
+  },
+
+
+  setTypeFontB: function(){
+    append(config.TXT_FONT_B);
+  },
+
+
+  setTextNormal: function(){
+    append(config.TXT_NORMAL);
+  },
+
+
+  setTextDoubleHeight: function(){
+    append(config.TXT_2HEIGHT);
+  },
+
+
+  setTextDoubleWidth: function(){
+    append(config.TXT_2WIDTH);
+  },
+
+  setTextQuadArea: function(){
+    append(config.TXT_4SQUARE);
+  },
+
+
+  newLine: function(){
+    append(config.CTL_LF);
+  },
+
+
+  drawLine: function(){
+    // module.exports.newLine();
+    for(var i=0; i<printerConfig.width; i++) {
+      if (printerConfig.lineChar) append(new Buffer(printerConfig.lineChar));
+      else append(new Buffer([196]));
+    }
+    module.exports.newLine();
+  },
+
+
+  leftRight: function(left, right){
+    append(left.toString());
+    var width = printerConfig.width - left.toString().length - right.toString().length;
+    for(var i=0; i<width; i++){
+      append(new Buffer(" "));
+    }
+    append(right.toString());
+    module.exports.newLine();
+  },
+
+
+  table: function(data){
+    var cellWidth = printerConfig.width/data.length;
+    for(var i=0; i<data.length; i++){
+      append(data[i].toString());
+      var spaces = cellWidth - data[i].toString().length;
+      for(var j=0; j<spaces; j++){
+        append(new Buffer(" "));
+      }
+    }
+    module.exports.newLine();
+  },
+
+
+  // Options: text, align, width, bold
+  tableCustom: function(data){
+    var cellWidth = printerConfig.width/data.length;
+    var secondLine = [];
+    var secondLineEnabled = false;
+
+    for(var i=0; i<data.length; i++){
+      var tooLong = false;
+      var obj = data[i];
+      obj.text = obj.text.toString();
+
+      if(obj.width) cellWidth = printerConfig.width * obj.width;
+      if(obj.bold) module.exports.bold(true);
+
+      // If text is too wide go to next line
+      if(cellWidth < obj.text.length){
+        tooLong = true;
+        obj.originalText = obj.text;
+        obj.text = obj.text.substring(0, cellWidth);
+      }
+
+      if(obj.align == "CENTER"){
+        var spaces = (cellWidth - obj.text.toString().length) / 2;
+        for(var j=0; j<spaces; j++){
+          append(new Buffer(" "));
+        }
+        if(obj.text != '')  append(obj.text);
+        for(var j=0; j<spaces-1; j++){
+          append(new Buffer(" "));
+        }
+
+      } else if(obj.align == "RIGHT") {
+        var spaces = cellWidth - obj.text.toString().length;
+        for(var j=0; j<spaces; j++){
+          append(new Buffer(" "));
+        }
+        if(obj.text != '') append(obj.text);
+
+      } else {
+        if(obj.text != '') append(obj.text);
+        var spaces = cellWidth - obj.text.toString().length;
+        for(var j=0; j<spaces; j++){
+          append(new Buffer(" "));
+        }
+
+      }
+
+      if(obj.bold) module.exports.bold(false);
+
+
+      if(tooLong){
+        secondLineEnabled = true;
+        obj.text = obj.originalText.substring(cellWidth-1);
+        secondLine.push(obj);
+      } else {
+        obj.text = "";
+        secondLine.push(obj);
+      }
+    }
+
+    module.exports.newLine();
+
+    // Print the second line
+    if(secondLineEnabled){
+      module.exports.tableCustom(secondLine);
+    }
+  },
+
+
+  isPrinterConnected: function(exists){
+    iface.isPrinterConnected(exists);
+  },
+
+
+  // ----------------------------------------------------- PRINT QR -----------------------------------------------------
+  printQR: function(str, settings){
+    if (printerConfig.type === printerTypes.STAR) {
+      append(star.printQR(str, settings));
+    } else if(printerConfig.type === printerTypes.EPSON) {
+      append(epson.printQR(str, settings));
+    } else {
+      console.error("QR not supported on '" + printerConfig.type + "' yet!");
+    }
+  },
+
+
+  // ----------------------------------------------------- PRINT BARCODE -----------------------------------------------------
+  printBarcode: function(data, type, settings){
+    if(printerConfig.type === printerTypes.EPSON) {
+      append(epson.printBarcode(data, type, settings));
+    } else {
+      console.error("Barcode not supported on '" + printerConfig.type + "' yet!");
+    }
+  },
+
+
+  // ----------------------------------------------------- PRINT MAXICODE -----------------------------------------------------
+  maxiCode: function(data, settings){
+    if(printerConfig.type === printerTypes.EPSON) {
+      append(epson.maxiCode(data, settings));
+    } else {
+      console.error("MaxiCode not supported on '" + printerConfig.type + "' yet!");
+    }
+  },
+
+
+  // ----------------------------------------------------- PRINT CODE128 -----------------------------------------------------
+  code128: function(data, settings) {
+    if (printerConfig.type === printerTypes.STAR) {
+      append(star.code128(data, settings));
+    } else {
+      console.error("Code128 not supported on '" + printerConfig.type + "' yet!");
+    }
+  },
+
+
+  // ----------------------------------------------------- PRINT PDF417 -----------------------------------------------------
+  pdf417: function(data, settings) {
+    if (printerConfig.type === printerTypes.STAR) {
+      append(star.pdf417(data, settings));
+    } else if(printerConfig.type === printerTypes.EPSON) {
+      append(epson.pdf417(data, settings));
+    } else {
+      console.error("PDF417 not supported on '" + printerConfig.type + "' yet!");
+    }
+  },
+
+
+
+  // ----------------------------------------------------- PRINT IMAGE -----------------------------------------------------
+  printImage: function(image, callback){
+    try {
+      // Check if file exists
+      fs.accessSync(image);
+
+      // Check for file type
+      if(image.slice(-4) === ".png"){
+        if (printerConfig.type === printerTypes.STAR){
+          star.printImageStar(image, function(response){
+            if(response) append(response);
+            callback(response);
+          });
+        } else if(printerConfig.type === printerTypes.EPSON) {
+          epson.printImageEpson(image, function(response){
+            if(response) append(response);
+            callback(response);
+          });
+        } else {
+          console.error("Image print not supported on '" + printerConfig.type + "' yet!");
+        }
+      } else {
+        console.error("Image printing supports only PNG files!");
+        callback(false);
+      }
+    } catch (e) {
+      callback(false);
+    }
+  },
+
+
+  // ----------------------------------------------------- PRINT IMAGE BUFFER -----------------------------------------------------
+  printImageBuffer: function(buffer, callback){
+    var png = new PNG({
+      filterType: 4
+    }).parse(buffer);
+
+    png.on('parsed', function() {
+      if (printerConfig.type === printerTypes.STAR){
+        star._printImageBufferStar(this.width, this.height, this.data, function(response){
+          if(response) append(response);
+          callback(response);
+        });
+      } else {
+        epson._printImageBufferEpson(this.width, this.height, this.data, function(response){
+          if(response) append(response);
+          callback(response);
+        });
+      }
+    });
+  },
+
+
+  // ------------------------------ RAW ------------------------------
+  raw: function(text, cb) {
+    iface.execute(text, function (err) {
+      if (!err) {
+        if (typeof cb === "function") {
+          cb(null);
+        }
+      } else {
+        if (typeof cb === "function") {
+          cb(err);
+        }
+      }
+    });
+  }
 };
 
 
 // ------------------------------ Set international character set ------------------------------
-var setInternationalCharacterSet = function (charSet) {
-    if (printerConfig.type == 'star') {
-        // ------------------------------ Star Character set ------------------------------
-        if (charSet == "USA") return config.CHARCODE_PC437;
-        if (charSet == "JAPANESE") return config.CHARCODE_JIS;
-        if (charSet == "MULTI") return config.CHARCODE_PC858;
-        if (charSet == "PORTUGUESE") return config.CHARCODE_PC860;
-        if (charSet == "CANADIAN") return config.CHARCODE_PC863;
-        if (charSet == "NORDIC") return config.CHARCODE_PC865;
-        if (charSet == "GREEK") return config.CHARCODE_GREEK;
-        if (charSet == "HEBREW") return config.CHARCODE_HEBREW;
-        if (charSet == "WESTEUROPE") return config.CHARCODE_PC1252;
-        if (charSet == "CIRLILLIC") return config.CHARCODE_PC866;
-        if (charSet == "LATIN2") return config.CHARCODE_PC852;
-        if (charSet == "SLOVENIA") return config.CHARCODE_PC852;
-        if (charSet == "THAI42") return config.CHARCODE_THAI42;
-        if (charSet == "THAI11") return config.CHARCODE_THAI11;
-        if (charSet == "THAI13") return config.CHARCODE_THAI13;
-        if (charSet == "THAI14") return config.CHARCODE_THAI14;
-        if (charSet == "THAI16") return config.CHARCODE_THAI16;
-        if (charSet == "THAI17") return config.CHARCODE_THAI17;
-        if (charSet == "THAI18") return config.CHARCODE_THAI18;
-        return null;
-    } else {
-        // ------------------------------ Epson Character set ------------------------------
-        if (charSet == "USA") return config.CHARCODE_USA;
-        if (charSet == "FRANCE") return config.CHARCODE_FRANCE;
-        if (charSet == "GERMANY") return config.CHARCODE_GERMANY;
-        if (charSet == "UK") return config.CHARCODE_UK;
-        if (charSet == "DENMARK1") return config.CHARCODE_DENMARK1;
-        if (charSet == "SWEDEN") return config.CHARCODE_SWEDEN;
-        if (charSet == "ITALY") return config.CHARCODE_ITALY;
-        if (charSet == "SPAIN1") return config.CHARCODE_SPAIN1;
-        if (charSet == "JAPAN") return config.CHARCODE_JAPAN;
-        if (charSet == "NORWAY") return config.CHARCODE_NORWAY;
-        if (charSet == "DENMARK2") return config.CHARCODE_DENMARK2;
-        if (charSet == "SPAIN2") return config.CHARCODE_SPAIN2;
-        if (charSet == "LATINA") return config.CHARCODE_LATINA;
-        if (charSet == "KOREA") return config.CHARCODE_KOREA;
-        if (charSet == "SLOVENIA") return config.CHARCODE_SLOVENIA;
-        if (charSet == "CHINA") return config.CHARCODE_CHINA;
-        if (charSet == "VIETNAM") return config.CHARCODE_VIETNAM;
-        if (charSet == "ARABIA") return config.CHARCODE_ARABIA;
-        return null;
-    }
+var setInternationalCharacterSet = function(charSet){
+  if (printerConfig.type == 'star') {
+    // ------------------------------ Star Character set ------------------------------
+    if(charSet == "USA") return config.CHARCODE_PC437;
+    if(charSet == "JAPANESE") return config.CHARCODE_JIS;
+    if(charSet == "MULTI") return config.CHARCODE_PC858;
+    if(charSet == "PORTUGUESE") return config.CHARCODE_PC860;
+    if(charSet == "CANADIAN") return config.CHARCODE_PC863;
+    if(charSet == "NORDIC") return config.CHARCODE_PC865;
+    if(charSet == "GREEK") return config.CHARCODE_GREEK;
+    if(charSet == "HEBREW") return config.CHARCODE_HEBREW;
+    if(charSet == "WESTEUROPE") return config.CHARCODE_PC1252;
+    if(charSet == "CIRLILLIC") return config.CHARCODE_PC866;
+    if(charSet == "LATIN2") return config.CHARCODE_PC852;
+    if(charSet == "SLOVENIA") return config.CHARCODE_PC852;
+    if(charSet == "THAI42") return config.CHARCODE_THAI42;
+    if(charSet == "THAI11") return config.CHARCODE_THAI11;
+    if(charSet == "THAI13") return config.CHARCODE_THAI13;
+    if(charSet == "THAI14") return config.CHARCODE_THAI14;
+    if(charSet == "THAI16") return config.CHARCODE_THAI16;
+    if(charSet == "THAI17") return config.CHARCODE_THAI17;
+    if(charSet == "THAI18") return config.CHARCODE_THAI18;
+    return null;
+  } else {
+    // ------------------------------ Epson Character set ------------------------------
+    if(charSet == "USA") return config.CHARCODE_USA;
+    if(charSet == "FRANCE") return config.CHARCODE_FRANCE;
+    if(charSet == "GERMANY") return config.CHARCODE_GERMANY;
+    if(charSet == "UK") return config.CHARCODE_UK;
+    if(charSet == "DENMARK1") return config.CHARCODE_DENMARK1;
+    if(charSet == "SWEDEN") return config.CHARCODE_SWEDEN;
+    if(charSet == "ITALY") return config.CHARCODE_ITALY;
+    if(charSet == "SPAIN1") return config.CHARCODE_SPAIN1;
+    if(charSet == "JAPAN") return config.CHARCODE_JAPAN;
+    if(charSet == "NORWAY") return config.CHARCODE_NORWAY;
+    if(charSet == "DENMARK2") return config.CHARCODE_DENMARK2;
+    if(charSet == "SPAIN2") return config.CHARCODE_SPAIN2;
+    if(charSet == "LATINA") return config.CHARCODE_LATINA;
+    if(charSet == "KOREA") return config.CHARCODE_KOREA;
+    if(charSet == "SLOVENIA") return config.CHARCODE_SLOVENIA;
+    if(charSet == "CHINA") return config.CHARCODE_CHINA;
+    if(charSet == "VIETNAM") return config.CHARCODE_VIETNAM;
+    if(charSet == "ARABIA") return config.CHARCODE_ARABIA;
+    return null;
+  }
 };
 
 
 // ------------------------------ Merge objects ------------------------------
-var mergeObjects = function (obj1, obj2) {
-    var obj3 = {};
-    for (var attrname in obj1) {
-        obj3[attrname] = obj1[attrname];
-    }
-    for (var attrname in obj2) {
-        obj3[attrname] = obj2[attrname];
-    }
-    return obj3;
+var mergeObjects = function(obj1, obj2) {
+  var obj3 = {};
+  for (var attrname in obj1) { obj3[attrname] = obj1[attrname]; }
+  for (var attrname in obj2) { obj3[attrname] = obj2[attrname]; }
+  return obj3;
 };
 
 

--- a/lib/core.js
+++ b/lib/core.js
@@ -1,546 +1,597 @@
 var fs = require('fs'),
-    net = require("net"),
     PNG = require('pngjs').PNG,
     star = require('./star'),
     epson = require('./epson'),
     getInterface = require("../interfaces");
 
 var printerTypes = {
-  EPSON: 'epson',
-  STAR: 'star'
+    EPSON: 'epson',
+    STAR: 'star'
 };
 
 var iface = null;
 var config = undefined;
 var buffer = null;
+/**
+ * @var {IPrinterConfig} printerConfig Object contains settings like width, characterSet, etc.
+ */
 var printerConfig;
+// Active code page.
+var codePage;
 
 module.exports = {
-  printerTypes: printerTypes,
-
-  init: function(initConfig){
-    if(initConfig.type === printerTypes.STAR){
-      config = require('../configs/starConfig');
-    } else {
-      config = require('../configs/epsonConfig');
-    }
-
-    iface = getInterface(initConfig.interface);
-
-    if(!initConfig.width) initConfig.width = 48;
-    if(!initConfig.characterSet) initConfig.characterSet = "SLOVENIA";
-    if(initConfig.removeSpecialCharacters === undefined) initConfig.removeSpecialCharacters = false;
-    if(initConfig.replaceSpecialCharacters === undefined) initConfig.replaceSpecialCharacters = true;
-    if(initConfig.extraSpecialCharacters) config.specialCharacters = mergeObjects(config.specialCharacters, initConfig.extraSpecialCharacters);
-
-    printerConfig = initConfig;
-  },
-
-
-  execute: function(cb){
-    iface.execute(buffer, function (err) {
-      if (!err) {
-        buffer = null;
-        if (typeof cb === "function") {
-          cb(null);
-        }
-      } else {
-        if (typeof cb === "function") {
-          cb(err);
-        }
-      }
-    });
-  },
-
-
-  cut: function(){
-    append(config.CTL_VT);
-    append(config.CTL_VT);
-    append(config.PAPER_FULL_CUT);
-    append(config.HW_INIT);
-  },
-
-
-  partialCut: function(){
-    append(config.CTL_VT);
-    append(config.CTL_VT);
-    append(config.PAPER_PART_CUT);
-    append(config.HW_INIT);
-  },
-
-
-  beep: function(){
-    if (printerConfig.type === printerTypes.STAR){
-      console.error("Beep not supported on STAR yet!");
-    } else {
-      append(config.BEEP);
-    }
-  },
-
-  getWidth: function(){
-    return parseInt(printerConfig.width);
-  },
-
-
-  getText: function(){
-    return buffer.toString();
-  },
-
-
-  getBuffer: function(){
-    return buffer;
-  },
-
-  setBuffer: function(newBuffer){
-    buffer = Buffer.from(newBuffer);
-  },
-
-  clear: function(){
-    buffer = null;
-  },
-
-
-  add: function(buffer){
-    append(buffer);
-  },
-
-
-  print: function(text){
-    append(text.toString());
-  },
-
-
-  println: function(text){
-    append(text.toString());
-    append("\n");
-  },
-
-
-  printVerticalTab: function(){
-    append(config.CTL_VT);
-  },
-
-
-  bold: function(enabled){
-    if(enabled) append(config.TXT_BOLD_ON);
-    else append(config.TXT_BOLD_OFF);
-  },
-
-
-  underline: function(enabled){
-    if(enabled) append(config.TXT_UNDERL_ON);
-    else append(config.TXT_UNDERL_OFF);
-  },
-
-
-  underlineThick: function(enabled){
-    if(enabled) append(config.TXT_UNDERL2_ON);
-    else append(config.TXT_UNDERL_OFF);
-  },
-
-
-  upsideDown: function(enabled){
-     if(enabled) append(config.UPSIDE_DOWN_ON);
-     else append(config.UPSIDE_DOWN_OFF);
-  },
-
-
-  invert: function(enabled){
-    if(enabled) append(config.TXT_INVERT_ON);
-    else append(config.TXT_INVERT_OFF);
-  },
-
-
-  openCashDrawer: function(){
-    if(printerConfig.type === printerTypes.STAR){
-      append(config.CD_KICK);
-    } else {
-      append(config.CD_KICK_2);
-      append(config.CD_KICK_5);
-    }
-  },
-
-
-  alignCenter: function (){
-    append(config.TXT_ALIGN_CT);
-  },
-
-
-  alignLeft: function (){
-    append(config.TXT_ALIGN_LT);
-  },
-
-
-  alignRight: function(){
-    append(config.TXT_ALIGN_RT);
-  },
-
-
-  setTypeFontA: function(){
-    append(config.TXT_FONT_A);
-  },
-
-
-  setTypeFontB: function(){
-    append(config.TXT_FONT_B);
-  },
-
-
-  setTextNormal: function(){
-    append(config.TXT_NORMAL);
-  },
-
-
-  setTextDoubleHeight: function(){
-    append(config.TXT_2HEIGHT);
-  },
-
-
-  setTextDoubleWidth: function(){
-    append(config.TXT_2WIDTH);
-  },
-
-  setTextQuadArea: function(){
-    append(config.TXT_4SQUARE);
-  },
-
-
-  newLine: function(){
-    append(config.CTL_LF);
-  },
-
-
-  drawLine: function(){
-    // module.exports.newLine();
-    for(var i=0; i<printerConfig.width; i++) {
-      if (printerConfig.lineChar) append(new Buffer(printerConfig.lineChar));
-      else append(new Buffer([196]));
-    }
-    module.exports.newLine();
-  },
-
-
-  leftRight: function(left, right){
-    append(left.toString());
-    var width = printerConfig.width - left.toString().length - right.toString().length;
-    for(var i=0; i<width; i++){
-      append(new Buffer(" "));
-    }
-    append(right.toString());
-    module.exports.newLine();
-  },
-
-
-  table: function(data){
-    var cellWidth = printerConfig.width/data.length;
-    for(var i=0; i<data.length; i++){
-      append(data[i].toString());
-      var spaces = cellWidth - data[i].toString().length;
-      for(var j=0; j<spaces; j++){
-        append(new Buffer(" "));
-      }
-    }
-    module.exports.newLine();
-  },
-
-
-  // Options: text, align, width, bold
-  tableCustom: function(data){
-    var cellWidth = printerConfig.width/data.length;
-    var secondLine = [];
-    var secondLineEnabled = false;
-
-    for(var i=0; i<data.length; i++){
-      var tooLong = false;
-      var obj = data[i];
-      obj.text = obj.text.toString();
-
-      if(obj.width) cellWidth = printerConfig.width * obj.width;
-      if(obj.bold) module.exports.bold(true);
-
-      // If text is too wide go to next line
-      if(cellWidth < obj.text.length){
-        tooLong = true;
-        obj.originalText = obj.text;
-        obj.text = obj.text.substring(0, cellWidth);
-      }
-
-      if(obj.align == "CENTER"){
-        var spaces = (cellWidth - obj.text.toString().length) / 2;
-        for(var j=0; j<spaces; j++){
-          append(new Buffer(" "));
-        }
-        if(obj.text != '')  append(obj.text);
-        for(var j=0; j<spaces-1; j++){
-          append(new Buffer(" "));
-        }
-
-      } else if(obj.align == "RIGHT") {
-        var spaces = cellWidth - obj.text.toString().length;
-        for(var j=0; j<spaces; j++){
-          append(new Buffer(" "));
-        }
-        if(obj.text != '') append(obj.text);
-
-      } else {
-        if(obj.text != '') append(obj.text);
-        var spaces = cellWidth - obj.text.toString().length;
-        for(var j=0; j<spaces; j++){
-          append(new Buffer(" "));
-        }
-
-      }
-
-      if(obj.bold) module.exports.bold(false);
-
-
-      if(tooLong){
-        secondLineEnabled = true;
-        obj.text = obj.originalText.substring(cellWidth-1);
-        secondLine.push(obj);
-      } else {
-        obj.text = "";
-        secondLine.push(obj);
-      }
-    }
-
-    module.exports.newLine();
-
-    // Print the second line
-    if(secondLineEnabled){
-      module.exports.tableCustom(secondLine);
-    }
-  },
-
-
-  isPrinterConnected: function(exists){
-    iface.isPrinterConnected(exists);
-  },
-
-
-  // ----------------------------------------------------- PRINT QR -----------------------------------------------------
-  printQR: function(str, settings){
-    if (printerConfig.type === printerTypes.STAR) {
-      append(star.printQR(str, settings));
-    } else if(printerConfig.type === printerTypes.EPSON) {
-      append(epson.printQR(str, settings));
-    } else {
-      console.error("QR not supported on '" + printerConfig.type + "' yet!");
-    }
-  },
-
-
-  // ----------------------------------------------------- PRINT BARCODE -----------------------------------------------------
-  printBarcode: function(data, type, settings){
-    if(printerConfig.type === printerTypes.EPSON) {
-      append(epson.printBarcode(data, type, settings));
-    } else {
-      console.error("Barcode not supported on '" + printerConfig.type + "' yet!");
-    }
-  },
-
-
-  // ----------------------------------------------------- PRINT MAXICODE -----------------------------------------------------
-  maxiCode: function(data, settings){
-    if(printerConfig.type === printerTypes.EPSON) {
-      append(epson.maxiCode(data, settings));
-    } else {
-      console.error("MaxiCode not supported on '" + printerConfig.type + "' yet!");
-    }
-  },
-
-
-  // ----------------------------------------------------- PRINT CODE128 -----------------------------------------------------
-  code128: function(data, settings) {
-    if (printerConfig.type === printerTypes.STAR) {
-      append(star.code128(data, settings));
-    } else {
-      console.error("Code128 not supported on '" + printerConfig.type + "' yet!");
-    }
-  },
-
-
-  // ----------------------------------------------------- PRINT PDF417 -----------------------------------------------------
-  pdf417: function(data, settings) {
-    if (printerConfig.type === printerTypes.STAR) {
-      append(star.pdf417(data, settings));
-    } else if(printerConfig.type === printerTypes.EPSON) {
-      append(epson.pdf417(data, settings));
-    } else {
-      console.error("PDF417 not supported on '" + printerConfig.type + "' yet!");
-    }
-  },
-
-
-
-  // ----------------------------------------------------- PRINT IMAGE -----------------------------------------------------
-  printImage: function(image, callback){
-    try {
-      // Check if file exists
-      fs.accessSync(image);
-
-      // Check for file type
-      if(image.slice(-4) === ".png"){
-        if (printerConfig.type === printerTypes.STAR){
-          star.printImageStar(image, function(response){
-            if(response) append(response);
-            callback(response);
-          });
-        } else if(printerConfig.type === printerTypes.EPSON) {
-          epson.printImageEpson(image, function(response){
-            if(response) append(response);
-            callback(response);
-          });
+    printerTypes: printerTypes,
+
+    /**
+     * Initialize printer.
+     *
+     * @param {IPrinterConfig} initConfig Configuration object
+     */
+    init: function (initConfig) {
+        if (initConfig.type === printerTypes.STAR) {
+            config = require('../configs/starConfig');
         } else {
-          console.error("Image print not supported on '" + printerConfig.type + "' yet!");
+            config = require('../configs/epsonConfig');
         }
-      } else {
-        console.error("Image printing supports only PNG files!");
-        callback(false);
-      }
-    } catch (e) {
-      callback(false);
+
+        iface = getInterface(initConfig.interface);
+
+        if (!initConfig.width) initConfig.width = 48;
+        if (!initConfig.characterSet) initConfig.characterSet = "SLOVENIA";
+        if (initConfig.removeSpecialCharacters === undefined) initConfig.removeSpecialCharacters = false;
+
+        printerConfig = initConfig;
+
+        // Code page initially active.
+        codePage = 'PC437_USA';
+        buffer = Buffer.from(config.CODE_PAGES[codePage][0]);
+    },
+
+
+    execute: function (cb) {
+        iface.execute(buffer, function (err) {
+            if (!err) {
+                buffer = null;
+                if (typeof cb === "function") {
+                    cb(null);
+                }
+            } else {
+                if (typeof cb === "function") {
+                    cb(err);
+                }
+            }
+        });
+    },
+
+
+    cut: function () {
+        append(config.CTL_VT);
+        append(config.CTL_VT);
+        append(config.PAPER_FULL_CUT);
+        append(config.HW_INIT);
+    },
+
+
+    partialCut: function () {
+        append(config.CTL_VT);
+        append(config.CTL_VT);
+        append(config.PAPER_PART_CUT);
+        append(config.HW_INIT);
+    },
+
+
+    beep: function () {
+        if (printerConfig.type === printerTypes.STAR) {
+            console.error("Beep not supported on STAR yet!");
+        } else {
+            append(config.BEEP);
+        }
+    },
+
+    getWidth: function () {
+        return parseInt(printerConfig.width);
+    },
+
+
+    getText: function () {
+        return buffer.toString();
+    },
+
+
+    getBuffer: function () {
+        return buffer;
+    },
+
+    setBuffer: function (newBuffer) {
+        buffer = Buffer.from(newBuffer);
+    },
+
+    clear: function () {
+        buffer = null;
+    },
+
+
+    add: function (buffer) {
+        append(buffer);
+    },
+
+
+    print: function (text) {
+        append(text.toString());
+    },
+
+
+    println: function (text) {
+        append(text.toString());
+        append("\n");
+    },
+
+
+    printVerticalTab: function () {
+        append(config.CTL_VT);
+    },
+
+
+    bold: function (enabled) {
+        if (enabled) append(config.TXT_BOLD_ON);
+        else append(config.TXT_BOLD_OFF);
+    },
+
+
+    underline: function (enabled) {
+        if (enabled) append(config.TXT_UNDERL_ON);
+        else append(config.TXT_UNDERL_OFF);
+    },
+
+
+    underlineThick: function (enabled) {
+        if (enabled) append(config.TXT_UNDERL2_ON);
+        else append(config.TXT_UNDERL_OFF);
+    },
+
+
+    upsideDown: function (enabled) {
+        if (enabled) append(config.UPSIDE_DOWN_ON);
+        else append(config.UPSIDE_DOWN_OFF);
+    },
+
+
+    invert: function (enabled) {
+        if (enabled) append(config.TXT_INVERT_ON);
+        else append(config.TXT_INVERT_OFF);
+    },
+
+
+    openCashDrawer: function () {
+        if (printerConfig.type === printerTypes.STAR) {
+            append(config.CD_KICK);
+        } else {
+            append(config.CD_KICK_2);
+            append(config.CD_KICK_5);
+        }
+    },
+
+
+    alignCenter: function () {
+        append(config.TXT_ALIGN_CT);
+    },
+
+
+    alignLeft: function () {
+        append(config.TXT_ALIGN_LT);
+    },
+
+
+    alignRight: function () {
+        append(config.TXT_ALIGN_RT);
+    },
+
+
+    setTypeFontA: function () {
+        append(config.TXT_FONT_A);
+    },
+
+
+    setTypeFontB: function () {
+        append(config.TXT_FONT_B);
+    },
+
+
+    setTextNormal: function () {
+        append(config.TXT_NORMAL);
+    },
+
+
+    setTextDoubleHeight: function () {
+        append(config.TXT_2HEIGHT);
+    },
+
+
+    setTextDoubleWidth: function () {
+        append(config.TXT_2WIDTH);
+    },
+
+    setTextQuadArea: function () {
+        append(config.TXT_4SQUARE);
+    },
+
+
+    newLine: function () {
+        append(config.CTL_LF);
+    },
+
+
+    drawLine: function () {
+        // module.exports.newLine();
+        for (var i = 0; i < printerConfig.width; i++) {
+            if (printerConfig.lineChar) append(new Buffer(printerConfig.lineChar));
+            else append(new Buffer([196]));
+        }
+        module.exports.newLine();
+    },
+
+
+    leftRight: function (left, right) {
+        append(left.toString());
+        var width = printerConfig.width - left.toString().length - right.toString().length;
+        for (var i = 0; i < width; i++) {
+            append(new Buffer(" "));
+        }
+        append(right.toString());
+        module.exports.newLine();
+    },
+
+
+    table: function (data) {
+        var cellWidth = printerConfig.width / data.length;
+        for (var i = 0; i < data.length; i++) {
+            append(data[i].toString());
+            var spaces = cellWidth - data[i].toString().length;
+            for (var j = 0; j < spaces; j++) {
+                append(new Buffer(" "));
+            }
+        }
+        module.exports.newLine();
+    },
+
+
+    // Options: text, align, width, bold
+    tableCustom: function (data) {
+        var cellWidth = printerConfig.width / data.length;
+        var secondLine = [];
+        var secondLineEnabled = false;
+
+        for (var i = 0; i < data.length; i++) {
+            var tooLong = false;
+            var obj = data[i];
+            obj.text = obj.text.toString();
+
+            if (obj.width) cellWidth = printerConfig.width * obj.width;
+            if (obj.bold) module.exports.bold(true);
+
+            // If text is too wide go to next line
+            if (cellWidth < obj.text.length) {
+                tooLong = true;
+                obj.originalText = obj.text;
+                obj.text = obj.text.substring(0, cellWidth);
+            }
+
+            if (obj.align == "CENTER") {
+                var spaces = (cellWidth - obj.text.toString().length) / 2;
+                for (var j = 0; j < spaces; j++) {
+                    append(new Buffer(" "));
+                }
+                if (obj.text != '') append(obj.text);
+                for (var j = 0; j < spaces - 1; j++) {
+                    append(new Buffer(" "));
+                }
+
+            } else if (obj.align == "RIGHT") {
+                var spaces = cellWidth - obj.text.toString().length;
+                for (var j = 0; j < spaces; j++) {
+                    append(new Buffer(" "));
+                }
+                if (obj.text != '') append(obj.text);
+
+            } else {
+                if (obj.text != '') append(obj.text);
+                var spaces = cellWidth - obj.text.toString().length;
+                for (var j = 0; j < spaces; j++) {
+                    append(new Buffer(" "));
+                }
+
+            }
+
+            if (obj.bold) module.exports.bold(false);
+
+
+            if (tooLong) {
+                secondLineEnabled = true;
+                obj.text = obj.originalText.substring(cellWidth - 1);
+                secondLine.push(obj);
+            } else {
+                obj.text = "";
+                secondLine.push(obj);
+            }
+        }
+
+        module.exports.newLine();
+
+        // Print the second line
+        if (secondLineEnabled) {
+            module.exports.tableCustom(secondLine);
+        }
+    },
+
+
+    isPrinterConnected: function (exists) {
+        iface.isPrinterConnected(exists);
+    },
+
+
+    // ----------------------------------------------------- PRINT QR
+    // -----------------------------------------------------
+    printQR: function (str, settings) {
+        if (printerConfig.type === printerTypes.STAR) {
+            append(star.printQR(str, settings));
+        } else if (printerConfig.type === printerTypes.EPSON) {
+            append(epson.printQR(str, settings));
+        } else {
+            console.error("QR not supported on '" + printerConfig.type + "' yet!");
+        }
+    },
+
+
+    // ----------------------------------------------------- PRINT BARCODE
+    // -----------------------------------------------------
+    printBarcode: function (data, type, settings) {
+        if (printerConfig.type === printerTypes.EPSON) {
+            append(epson.printBarcode(data, type, settings));
+        } else {
+            console.error("Barcode not supported on '" + printerConfig.type + "' yet!");
+        }
+    },
+
+
+    // ----------------------------------------------------- PRINT MAXICODE
+    // -----------------------------------------------------
+    maxiCode: function (data, settings) {
+        if (printerConfig.type === printerTypes.EPSON) {
+            append(epson.maxiCode(data, settings));
+        } else {
+            console.error("MaxiCode not supported on '" + printerConfig.type + "' yet!");
+        }
+    },
+
+
+    // ----------------------------------------------------- PRINT CODE128
+    // -----------------------------------------------------
+    code128: function (data, settings) {
+        if (printerConfig.type === printerTypes.STAR) {
+            append(star.code128(data, settings));
+        } else {
+            console.error("Code128 not supported on '" + printerConfig.type + "' yet!");
+        }
+    },
+
+
+    // ----------------------------------------------------- PRINT PDF417
+    // -----------------------------------------------------
+    pdf417: function (data, settings) {
+        if (printerConfig.type === printerTypes.STAR) {
+            append(star.pdf417(data, settings));
+        } else if (printerConfig.type === printerTypes.EPSON) {
+            append(epson.pdf417(data, settings));
+        } else {
+            console.error("PDF417 not supported on '" + printerConfig.type + "' yet!");
+        }
+    },
+
+
+    // ----------------------------------------------------- PRINT IMAGE
+    // -----------------------------------------------------
+    printImage: function (image, callback) {
+        try {
+            // Check if file exists
+            fs.accessSync(image);
+
+            // Check for file type
+            if (image.slice(-4) === ".png") {
+                if (printerConfig.type === printerTypes.STAR) {
+                    star.printImageStar(image, function (response) {
+                        if (response) append(response);
+                        callback(response);
+                    });
+                } else if (printerConfig.type === printerTypes.EPSON) {
+                    epson.printImageEpson(image, function (response) {
+                        if (response) append(response);
+                        callback(response);
+                    });
+                } else {
+                    console.error("Image print not supported on '" + printerConfig.type + "' yet!");
+                }
+            } else {
+                console.error("Image printing supports only PNG files!");
+                callback(false);
+            }
+        } catch (e) {
+            callback(false);
+        }
+    },
+
+
+    // ----------------------------------------------------- PRINT IMAGE BUFFER
+    // -----------------------------------------------------
+    printImageBuffer: function (buffer, callback) {
+        var png = new PNG({
+            filterType: 4
+        }).parse(buffer);
+
+        png.on('parsed', function () {
+            if (printerConfig.type === printerTypes.STAR) {
+                star._printImageBufferStar(this.width, this.height, this.data, function (response) {
+                    if (response) append(response);
+                    callback(response);
+                });
+            } else {
+                epson._printImageBufferEpson(this.width, this.height, this.data, function (response) {
+                    if (response) append(response);
+                    callback(response);
+                });
+            }
+        });
+    },
+
+
+    // ------------------------------ RAW ------------------------------
+    raw: function (text, cb) {
+        iface.execute(text, function (err) {
+            if (!err) {
+                if (typeof cb === "function") {
+                    cb(null);
+                }
+            } else {
+                if (typeof cb === "function") {
+                    cb(err);
+                }
+            }
+        });
     }
-  },
-
-
-  // ----------------------------------------------------- PRINT IMAGE BUFFER -----------------------------------------------------
-  printImageBuffer: function(buffer, callback){
-    var png = new PNG({
-      filterType: 4
-    }).parse(buffer);
-
-    png.on('parsed', function() {
-      if (printerConfig.type === printerTypes.STAR){
-        star._printImageBufferStar(this.width, this.height, this.data, function(response){
-          if(response) append(response);
-          callback(response);
-        });
-      } else {
-        epson._printImageBufferEpson(this.width, this.height, this.data, function(response){
-          if(response) append(response);
-          callback(response);
-        });
-      }
-    });
-  },
-
-
-  // ------------------------------ RAW ------------------------------
-  raw: function(text, cb) {
-    iface.execute(text, function (err) {
-      if (!err) {
-        if (typeof cb === "function") {
-          cb(null);
-        }
-      } else {
-        if (typeof cb === "function") {
-          cb(err);
-        }
-      }
-    });
-  }
 };
 
 
 // ------------------------------ Set international character set ------------------------------
-var setInternationalCharacterSet = function(charSet){
-  if (printerConfig.type == 'star') {
-    // ------------------------------ Star Character set ------------------------------
-    if(charSet == "USA") return config.CHARCODE_PC437;
-    if(charSet == "JAPANESE") return config.CHARCODE_JIS;
-    if(charSet == "MULTI") return config.CHARCODE_PC858;
-    if(charSet == "PORTUGUESE") return config.CHARCODE_PC860;
-    if(charSet == "CANADIAN") return config.CHARCODE_PC863;
-    if(charSet == "NORDIC") return config.CHARCODE_PC865;
-    if(charSet == "GREEK") return config.CHARCODE_GREEK;
-    if(charSet == "HEBREW") return config.CHARCODE_HEBREW;
-    if(charSet == "WESTEUROPE") return config.CHARCODE_PC1252;
-    if(charSet == "CIRLILLIC") return config.CHARCODE_PC866;
-    if(charSet == "LATIN2") return config.CHARCODE_PC852;
-    if(charSet == "SLOVENIA") return config.CHARCODE_PC852;
-    if(charSet == "THAI42") return config.CHARCODE_THAI42;
-    if(charSet == "THAI11") return config.CHARCODE_THAI11;
-    if(charSet == "THAI13") return config.CHARCODE_THAI13;
-    if(charSet == "THAI14") return config.CHARCODE_THAI14;
-    if(charSet == "THAI16") return config.CHARCODE_THAI16;
-    if(charSet == "THAI17") return config.CHARCODE_THAI17;
-    if(charSet == "THAI18") return config.CHARCODE_THAI18;
-    return null;
-  } else {
-    // ------------------------------ Epson Character set ------------------------------
-    if(charSet == "USA") return config.CHARCODE_USA;
-    if(charSet == "FRANCE") return config.CHARCODE_FRANCE;
-    if(charSet == "GERMANY") return config.CHARCODE_GERMANY;
-    if(charSet == "UK") return config.CHARCODE_UK;
-    if(charSet == "DENMARK1") return config.CHARCODE_DENMARK1;
-    if(charSet == "SWEDEN") return config.CHARCODE_SWEDEN;
-    if(charSet == "ITALY") return config.CHARCODE_ITALY;
-    if(charSet == "SPAIN1") return config.CHARCODE_SPAIN1;
-    if(charSet == "JAPAN") return config.CHARCODE_JAPAN;
-    if(charSet == "NORWAY") return config.CHARCODE_NORWAY;
-    if(charSet == "DENMARK2") return config.CHARCODE_DENMARK2;
-    if(charSet == "SPAIN2") return config.CHARCODE_SPAIN2;
-    if(charSet == "LATINA") return config.CHARCODE_LATINA;
-    if(charSet == "KOREA") return config.CHARCODE_KOREA;
-    if(charSet == "SLOVENIA") return config.CHARCODE_SLOVENIA;
-    if(charSet == "CHINA") return config.CHARCODE_CHINA;
-    if(charSet == "VIETNAM") return config.CHARCODE_VIETNAM;
-    if(charSet == "ARABIA") return config.CHARCODE_ARABIA;
-    return null;
-  }
+var setInternationalCharacterSet = function (charSet) {
+    if (printerConfig.type == 'star') {
+        // ------------------------------ Star Character set ------------------------------
+        if (charSet == "USA") return config.CHARCODE_PC437;
+        if (charSet == "JAPANESE") return config.CHARCODE_JIS;
+        if (charSet == "MULTI") return config.CHARCODE_PC858;
+        if (charSet == "PORTUGUESE") return config.CHARCODE_PC860;
+        if (charSet == "CANADIAN") return config.CHARCODE_PC863;
+        if (charSet == "NORDIC") return config.CHARCODE_PC865;
+        if (charSet == "GREEK") return config.CHARCODE_GREEK;
+        if (charSet == "HEBREW") return config.CHARCODE_HEBREW;
+        if (charSet == "WESTEUROPE") return config.CHARCODE_PC1252;
+        if (charSet == "CIRLILLIC") return config.CHARCODE_PC866;
+        if (charSet == "LATIN2") return config.CHARCODE_PC852;
+        if (charSet == "SLOVENIA") return config.CHARCODE_PC852;
+        if (charSet == "THAI42") return config.CHARCODE_THAI42;
+        if (charSet == "THAI11") return config.CHARCODE_THAI11;
+        if (charSet == "THAI13") return config.CHARCODE_THAI13;
+        if (charSet == "THAI14") return config.CHARCODE_THAI14;
+        if (charSet == "THAI16") return config.CHARCODE_THAI16;
+        if (charSet == "THAI17") return config.CHARCODE_THAI17;
+        if (charSet == "THAI18") return config.CHARCODE_THAI18;
+        return null;
+    } else {
+        // ------------------------------ Epson Character set ------------------------------
+        if (charSet == "USA") return config.CHARCODE_USA;
+        if (charSet == "FRANCE") return config.CHARCODE_FRANCE;
+        if (charSet == "GERMANY") return config.CHARCODE_GERMANY;
+        if (charSet == "UK") return config.CHARCODE_UK;
+        if (charSet == "DENMARK1") return config.CHARCODE_DENMARK1;
+        if (charSet == "SWEDEN") return config.CHARCODE_SWEDEN;
+        if (charSet == "ITALY") return config.CHARCODE_ITALY;
+        if (charSet == "SPAIN1") return config.CHARCODE_SPAIN1;
+        if (charSet == "JAPAN") return config.CHARCODE_JAPAN;
+        if (charSet == "NORWAY") return config.CHARCODE_NORWAY;
+        if (charSet == "DENMARK2") return config.CHARCODE_DENMARK2;
+        if (charSet == "SPAIN2") return config.CHARCODE_SPAIN2;
+        if (charSet == "LATINA") return config.CHARCODE_LATINA;
+        if (charSet == "KOREA") return config.CHARCODE_KOREA;
+        if (charSet == "SLOVENIA") return config.CHARCODE_SLOVENIA;
+        if (charSet == "CHINA") return config.CHARCODE_CHINA;
+        if (charSet == "VIETNAM") return config.CHARCODE_VIETNAM;
+        if (charSet == "ARABIA") return config.CHARCODE_ARABIA;
+        return null;
+    }
 };
 
 
 // ------------------------------ Merge objects ------------------------------
-var mergeObjects = function(obj1, obj2) {
-  var obj3 = {};
-  for (var attrname in obj1) { obj3[attrname] = obj1[attrname]; }
-  for (var attrname in obj2) { obj3[attrname] = obj2[attrname]; }
-  return obj3;
+var mergeObjects = function (obj1, obj2) {
+    var obj3 = {};
+    for (var attrname in obj1) {
+        obj3[attrname] = obj1[attrname];
+    }
+    for (var attrname in obj2) {
+        obj3[attrname] = obj2[attrname];
+    }
+    return obj3;
 };
 
 
-// ------------------------------ Append ------------------------------
-var append = function(buff){
-  if(typeof buff === "string"){
+/**
+ * Append text to buffer.
+ *
+ * @param {string|Buffer} text Text or control codes
+ * @returns void
+ */
+function append(text) {
 
-    // Remove special characters
-    if(printerConfig.removeSpecialCharacters) {
-      var unorm = require('unorm');
-      var combining = /[\u0300-\u036F]/g;
-      buff = unorm.nfkd(buff).replace(combining, '');
-    }
+    if (typeof text === "string") {
 
-    var endBuff = null;
-    for(var i=0; i<buff.length; i++) {
-      var value = buff[i];
-      var tempBuff = new Buffer(value);
-
-      // Replace special characters
-      if (printerConfig.replaceSpecialCharacters) {
-        for (var key in config.specialCharacters) {
-          if (value === key) {
-            tempBuff = new Buffer([config.specialCharacters[key]]);
-            break;
-          }
+        // Remove special characters.
+        if (printerConfig.removeSpecialCharacters) {
+            const unorm = require('unorm');
+            const combining = /[\u0300-\u036F]/g;
+            text = unorm.nfkd(text).replace(combining, '');
         }
-      }
 
-      if (endBuff) endBuff = Buffer.concat([endBuff, tempBuff]);
-      else endBuff = tempBuff;
+        let endBuff = null;
+        for (const char of text) {
+
+            /**
+             * We only have to convert characters that are outside the ASCII range.
+             * @var {string|Buffer} code
+             */
+            let code = char;
+            if (!/^[\x00-\x7F]$/.test(char)) {
+
+                // We only need iconv when we encounter non-ascii characters.
+                const iconv = require('iconv-lite');
+
+                // Test if the active code page can print the current character.
+                try {
+                    code = iconv.encode(char, config.CODE_PAGES[codePage][1]);
+                } catch (e) {
+                    // Probably encoding not recognized.
+                    console.error(e);
+                    code = '?';
+                }
+
+                if (code.toString() === '?') {
+
+                    // Character not available in active code page, now try all other code pages.
+                    for (const tmpCodePageKey of Object.keys(config.CODE_PAGES)) {
+                        const tmpCodePage = config.CODE_PAGES[tmpCodePageKey];
+
+                        try {
+                            code = iconv.encode(char, tmpCodePage[1]);
+                        } catch (e) {
+                            // Probably encoding not recognized.
+                            console.error(e);
+                        }
+
+                        if (code.toString() !== '?') {
+                            // We found a match, change active code page.
+                            codePage = tmpCodePageKey;
+                            code = Buffer.concat([tmpCodePage[0], code]);
+                            break;
+                        }
+                    }
+                }
+            }
+            endBuff = endBuff ? Buffer.concat([endBuff, Buffer.from(code)]) : Buffer.from(code);
+        }
+        text = endBuff;
     }
 
-    buff = endBuff;
-  }
-
-  // Append character set
-  if(!buffer && printerConfig.characterSet) buffer = setInternationalCharacterSet(printerConfig.characterSet);
-
-  // Append new buffer
-  if (buffer) {
-    buffer = Buffer.concat([buffer,buff]);
-  } else {
-    buffer = buff;
-  }
-};
+    // Append new buffer
+    if (buffer) {
+        buffer = Buffer.concat([buffer, text]);
+    } else {
+        buffer = text;
+    }
+}

--- a/lib/core.js
+++ b/lib/core.js
@@ -1,12 +1,14 @@
-var fs = require('fs'),
-    PNG = require('pngjs').PNG,
-    star = require('./star'),
-    epson = require('./epson'),
-    getInterface = require("../interfaces");
+const fs = require('fs');
+const PNG = require('pngjs').PNG;
+const star = require('./star');
+const epson = require('./epson');
+const getInterface = require("../interfaces");
+// We only need iconv when we encounter non-ascii characters.
+const iconv = require('iconv-lite');
 
-var printerTypes = {
-    EPSON: 'epson',
-    STAR: 'star'
+const printerTypes = {
+  EPSON: 'epson',
+  STAR: 'star'
 };
 
 var iface = null;
@@ -37,18 +39,16 @@ module.exports = {
     iface = getInterface(initConfig.interface);
 
     if (!initConfig.width) initConfig.width = 48;
-    if (!initConfig.characterSet) initConfig.characterSet = "SLOVENIA";
     if (initConfig.removeSpecialCharacters === undefined) initConfig.removeSpecialCharacters = false;
 
     printerConfig = initConfig;
 
-    // Code page initially active.
-    codePage = 'PC437_USA';
-    buffer = Buffer.from(config.CODE_PAGES[codePage][0]);
+    // Set initial code page.
+    this.setCodePage('PC437_USA');
   },
 
 
-  execute: function(cb){
+  execute: function (cb) {
     iface.execute(buffer, function (err) {
       if (!err) {
         buffer = null;
@@ -64,7 +64,7 @@ module.exports = {
   },
 
 
-  cut: function(){
+  cut: function () {
     append(config.CTL_VT);
     append(config.CTL_VT);
     append(config.PAPER_FULL_CUT);
@@ -72,7 +72,7 @@ module.exports = {
   },
 
 
-  partialCut: function(){
+  partialCut: function () {
     append(config.CTL_VT);
     append(config.CTL_VT);
     append(config.PAPER_PART_CUT);
@@ -80,90 +80,90 @@ module.exports = {
   },
 
 
-  beep: function(){
-    if (printerConfig.type === printerTypes.STAR){
+  beep: function () {
+    if (printerConfig.type === printerTypes.STAR) {
       console.error("Beep not supported on STAR yet!");
     } else {
       append(config.BEEP);
     }
   },
 
-  getWidth: function(){
+  getWidth: function () {
     return parseInt(printerConfig.width);
   },
 
 
-  getText: function(){
+  getText: function () {
     return buffer.toString();
   },
 
 
-  getBuffer: function(){
+  getBuffer: function () {
     return buffer;
   },
 
-  setBuffer: function(newBuffer){
+  setBuffer: function (newBuffer) {
     buffer = Buffer.from(newBuffer);
   },
 
-  clear: function(){
+  clear: function () {
     buffer = null;
   },
 
 
-  add: function(buffer){
+  add: function (buffer) {
     append(buffer);
   },
 
 
-  print: function(text){
+  print: function (text) {
     append(text.toString());
   },
 
 
-  println: function(text){
+  println: function (text) {
     append(text.toString());
     append("\n");
   },
 
 
-  printVerticalTab: function(){
+  printVerticalTab: function () {
     append(config.CTL_VT);
   },
 
 
-  bold: function(enabled){
-    if(enabled) append(config.TXT_BOLD_ON);
+  bold: function (enabled) {
+    if (enabled) append(config.TXT_BOLD_ON);
     else append(config.TXT_BOLD_OFF);
   },
 
 
-  underline: function(enabled){
-    if(enabled) append(config.TXT_UNDERL_ON);
+  underline: function (enabled) {
+    if (enabled) append(config.TXT_UNDERL_ON);
     else append(config.TXT_UNDERL_OFF);
   },
 
 
-  underlineThick: function(enabled){
-    if(enabled) append(config.TXT_UNDERL2_ON);
+  underlineThick: function (enabled) {
+    if (enabled) append(config.TXT_UNDERL2_ON);
     else append(config.TXT_UNDERL_OFF);
   },
 
 
-  upsideDown: function(enabled){
-     if(enabled) append(config.UPSIDE_DOWN_ON);
-     else append(config.UPSIDE_DOWN_OFF);
+  upsideDown: function (enabled) {
+    if (enabled) append(config.UPSIDE_DOWN_ON);
+    else append(config.UPSIDE_DOWN_OFF);
   },
 
 
-  invert: function(enabled){
-    if(enabled) append(config.TXT_INVERT_ON);
+  invert: function (enabled) {
+    if (enabled) append(config.TXT_INVERT_ON);
     else append(config.TXT_INVERT_OFF);
   },
 
 
-  openCashDrawer: function(){
-    if(printerConfig.type === printerTypes.STAR){
+  openCashDrawer: function () {
+    if (printerConfig.type === printerTypes.STAR) {
       append(config.CD_KICK);
     } else {
       append(config.CD_KICK_2);
@@ -172,58 +172,58 @@ module.exports = {
   },
 
 
-  alignCenter: function (){
+  alignCenter: function () {
     append(config.TXT_ALIGN_CT);
   },
 
 
-  alignLeft: function (){
+  alignLeft: function () {
     append(config.TXT_ALIGN_LT);
   },
 
 
-  alignRight: function(){
+  alignRight: function () {
     append(config.TXT_ALIGN_RT);
   },
 
 
-  setTypeFontA: function(){
+  setTypeFontA: function () {
     append(config.TXT_FONT_A);
   },
 
 
-  setTypeFontB: function(){
+  setTypeFontB: function () {
     append(config.TXT_FONT_B);
   },
 
 
-  setTextNormal: function(){
+  setTextNormal: function () {
     append(config.TXT_NORMAL);
   },
 
 
-  setTextDoubleHeight: function(){
+  setTextDoubleHeight: function () {
     append(config.TXT_2HEIGHT);
   },
 
 
-  setTextDoubleWidth: function(){
+  setTextDoubleWidth: function () {
     append(config.TXT_2WIDTH);
   },
 
-  setTextQuadArea: function(){
+  setTextQuadArea: function () {
     append(config.TXT_4SQUARE);
   },
 
 
-  newLine: function(){
+  newLine: function () {
     append(config.CTL_LF);
   },
 
 
-  drawLine: function(){
+  drawLine: function () {
     // module.exports.newLine();
-    for(var i=0; i<printerConfig.width; i++) {
+    for (var i = 0; i < printerConfig.width; i++) {
       if (printerConfig.lineChar) append(new Buffer(printerConfig.lineChar));
       else append(new Buffer([196]));
     }
@@ -231,10 +231,10 @@ module.exports = {
   },
 
 
-  leftRight: function(left, right){
+  leftRight: function (left, right) {
     append(left.toString());
     var width = printerConfig.width - left.toString().length - right.toString().length;
-    for(var i=0; i<width; i++){
+    for (var i = 0; i < width; i++) {
       append(new Buffer(" "));
     }
     append(right.toString());
@@ -242,12 +242,12 @@ module.exports = {
   },
 
 
-  table: function(data){
-    var cellWidth = printerConfig.width/data.length;
-    for(var i=0; i<data.length; i++){
+  table: function (data) {
+    var cellWidth = printerConfig.width / data.length;
+    for (var i = 0; i < data.length; i++) {
       append(data[i].toString());
       var spaces = cellWidth - data[i].toString().length;
-      for(var j=0; j<spaces; j++){
+      for (var j = 0; j < spaces; j++) {
         append(new Buffer(" "));
       }
     }
@@ -256,58 +256,58 @@ module.exports = {
 
 
   // Options: text, align, width, bold
-  tableCustom: function(data){
-    var cellWidth = printerConfig.width/data.length;
+  tableCustom: function (data) {
+    var cellWidth = printerConfig.width / data.length;
     var secondLine = [];
     var secondLineEnabled = false;
 
-    for(var i=0; i<data.length; i++){
+    for (var i = 0; i < data.length; i++) {
       var tooLong = false;
       var obj = data[i];
       obj.text = obj.text.toString();
 
-      if(obj.width) cellWidth = printerConfig.width * obj.width;
-      if(obj.bold) module.exports.bold(true);
+      if (obj.width) cellWidth = printerConfig.width * obj.width;
+      if (obj.bold) module.exports.bold(true);
 
       // If text is too wide go to next line
-      if(cellWidth < obj.text.length){
+      if (cellWidth < obj.text.length) {
         tooLong = true;
         obj.originalText = obj.text;
         obj.text = obj.text.substring(0, cellWidth);
       }
 
-      if(obj.align == "CENTER"){
+      if (obj.align == "CENTER") {
         var spaces = (cellWidth - obj.text.toString().length) / 2;
-        for(var j=0; j<spaces; j++){
+        for (var j = 0; j < spaces; j++) {
           append(new Buffer(" "));
         }
-        if(obj.text != '')  append(obj.text);
-        for(var j=0; j<spaces-1; j++){
+        if (obj.text != '') append(obj.text);
+        for (var j = 0; j < spaces - 1; j++) {
           append(new Buffer(" "));
         }
 
-      } else if(obj.align == "RIGHT") {
+      } else if (obj.align == "RIGHT") {
         var spaces = cellWidth - obj.text.toString().length;
-        for(var j=0; j<spaces; j++){
+        for (var j = 0; j < spaces; j++) {
           append(new Buffer(" "));
         }
-        if(obj.text != '') append(obj.text);
+        if (obj.text != '') append(obj.text);
 
       } else {
-        if(obj.text != '') append(obj.text);
+        if (obj.text != '') append(obj.text);
         var spaces = cellWidth - obj.text.toString().length;
-        for(var j=0; j<spaces; j++){
+        for (var j = 0; j < spaces; j++) {
           append(new Buffer(" "));
         }
 
       }
 
-      if(obj.bold) module.exports.bold(false);
+      if (obj.bold) module.exports.bold(false);
 
 
-      if(tooLong){
+      if (tooLong) {
         secondLineEnabled = true;
-        obj.text = obj.originalText.substring(cellWidth-1);
+        obj.text = obj.originalText.substring(cellWidth - 1);
         secondLine.push(obj);
       } else {
         obj.text = "";
@@ -318,22 +318,21 @@ module.exports = {
     module.exports.newLine();
 
     // Print the second line
-    if(secondLineEnabled){
+    if (secondLineEnabled) {
       module.exports.tableCustom(secondLine);
     }
   },
 
 
-  isPrinterConnected: function(exists){
+  isPrinterConnected: function (exists) {
     iface.isPrinterConnected(exists);
   },
 
 
-  // ----------------------------------------------------- PRINT QR -----------------------------------------------------
-  printQR: function(str, settings){
+  printQR: function (str, settings) {
     if (printerConfig.type === printerTypes.STAR) {
       append(star.printQR(str, settings));
-    } else if(printerConfig.type === printerTypes.EPSON) {
+    } else if (printerConfig.type === printerTypes.EPSON) {
       append(epson.printQR(str, settings));
     } else {
       console.error("QR not supported on '" + printerConfig.type + "' yet!");
@@ -341,9 +340,8 @@ module.exports = {
   },
 
 
-  // ----------------------------------------------------- PRINT BARCODE -----------------------------------------------------
-  printBarcode: function(data, type, settings){
-    if(printerConfig.type === printerTypes.EPSON) {
+  printBarcode: function (data, type, settings) {
+    if (printerConfig.type === printerTypes.EPSON) {
       append(epson.printBarcode(data, type, settings));
     } else {
       console.error("Barcode not supported on '" + printerConfig.type + "' yet!");
@@ -351,9 +349,8 @@ module.exports = {
   },
 
 
-  // ----------------------------------------------------- PRINT MAXICODE -----------------------------------------------------
-  maxiCode: function(data, settings){
-    if(printerConfig.type === printerTypes.EPSON) {
+  maxiCode: function (data, settings) {
+    if (printerConfig.type === printerTypes.EPSON) {
       append(epson.maxiCode(data, settings));
     } else {
       console.error("MaxiCode not supported on '" + printerConfig.type + "' yet!");
@@ -361,8 +358,7 @@ module.exports = {
   },
 
 
-  // ----------------------------------------------------- PRINT CODE128 -----------------------------------------------------
-  code128: function(data, settings) {
+  code128: function (data, settings) {
     if (printerConfig.type === printerTypes.STAR) {
       append(star.code128(data, settings));
     } else {
@@ -371,11 +367,10 @@ module.exports = {
   },
 
 
-  // ----------------------------------------------------- PRINT PDF417 -----------------------------------------------------
-  pdf417: function(data, settings) {
+  pdf417: function (data, settings) {
     if (printerConfig.type === printerTypes.STAR) {
       append(star.pdf417(data, settings));
-    } else if(printerConfig.type === printerTypes.EPSON) {
+    } else if (printerConfig.type === printerTypes.EPSON) {
       append(epson.pdf417(data, settings));
     } else {
       console.error("PDF417 not supported on '" + printerConfig.type + "' yet!");
@@ -383,23 +378,21 @@ module.exports = {
   },
 
 
-
-  // ----------------------------------------------------- PRINT IMAGE -----------------------------------------------------
-  printImage: function(image, callback){
+  printImage: function (image, callback) {
     try {
       // Check if file exists
       fs.accessSync(image);
 
       // Check for file type
-      if(image.slice(-4) === ".png"){
-        if (printerConfig.type === printerTypes.STAR){
-          star.printImageStar(image, function(response){
-            if(response) append(response);
+      if (image.slice(-4) === ".png") {
+        if (printerConfig.type === printerTypes.STAR) {
+          star.printImageStar(image, function (response) {
+            if (response) append(response);
             callback(response);
           });
-        } else if(printerConfig.type === printerTypes.EPSON) {
-          epson.printImageEpson(image, function(response){
-            if(response) append(response);
+        } else if (printerConfig.type === printerTypes.EPSON) {
+          epson.printImageEpson(image, function (response) {
+            if (response) append(response);
             callback(response);
           });
         } else {
@@ -415,21 +408,20 @@ module.exports = {
   },
 
 
-  // ----------------------------------------------------- PRINT IMAGE BUFFER -----------------------------------------------------
-  printImageBuffer: function(buffer, callback){
+  printImageBuffer: function (buffer, callback) {
     var png = new PNG({
       filterType: 4
     }).parse(buffer);
 
-    png.on('parsed', function() {
-      if (printerConfig.type === printerTypes.STAR){
-        star._printImageBufferStar(this.width, this.height, this.data, function(response){
-          if(response) append(response);
+    png.on('parsed', function () {
+      if (printerConfig.type === printerTypes.STAR) {
+        star._printImageBufferStar(this.width, this.height, this.data, function (response) {
+          if (response) append(response);
           callback(response);
         });
       } else {
-        epson._printImageBufferEpson(this.width, this.height, this.data, function(response){
-          if(response) append(response);
+        epson._printImageBufferEpson(this.width, this.height, this.data, function (response) {
+          if (response) append(response);
           callback(response);
         });
       }
@@ -437,8 +429,7 @@ module.exports = {
   },
 
 
-  // ------------------------------ RAW ------------------------------
-  raw: function(text, cb) {
+  raw: function (text, cb) {
     iface.execute(text, function (err) {
       if (!err) {
         if (typeof cb === "function") {
@@ -450,65 +441,26 @@ module.exports = {
         }
       }
     });
+  },
+
+
+  /**
+   * Name of the code page to make active.
+   * eg PC437_USA or ISO8859_15_LATIN9
+   *
+   * @param {string} codePageName Name of the code page in upper case
+   * @throws Error in case the code page is not recognized
+   */
+  setCodePage: function (codePageName) {
+    const codePageBuffer = config[`CODE_PAGE_${codePageName}`];
+    if (codePageBuffer) {
+      append(codePageBuffer);
+      codePage = codePageName;
+    } else {
+      throw new Error(`Code page not recognized: '${codePageName}'`);
+    }
   }
-};
 
-
-// ------------------------------ Set international character set ------------------------------
-var setInternationalCharacterSet = function(charSet){
-  if (printerConfig.type == 'star') {
-    // ------------------------------ Star Character set ------------------------------
-    if(charSet == "USA") return config.CHARCODE_PC437;
-    if(charSet == "JAPANESE") return config.CHARCODE_JIS;
-    if(charSet == "MULTI") return config.CHARCODE_PC858;
-    if(charSet == "PORTUGUESE") return config.CHARCODE_PC860;
-    if(charSet == "CANADIAN") return config.CHARCODE_PC863;
-    if(charSet == "NORDIC") return config.CHARCODE_PC865;
-    if(charSet == "GREEK") return config.CHARCODE_GREEK;
-    if(charSet == "HEBREW") return config.CHARCODE_HEBREW;
-    if(charSet == "WESTEUROPE") return config.CHARCODE_PC1252;
-    if(charSet == "CIRLILLIC") return config.CHARCODE_PC866;
-    if(charSet == "LATIN2") return config.CHARCODE_PC852;
-    if(charSet == "SLOVENIA") return config.CHARCODE_PC852;
-    if(charSet == "THAI42") return config.CHARCODE_THAI42;
-    if(charSet == "THAI11") return config.CHARCODE_THAI11;
-    if(charSet == "THAI13") return config.CHARCODE_THAI13;
-    if(charSet == "THAI14") return config.CHARCODE_THAI14;
-    if(charSet == "THAI16") return config.CHARCODE_THAI16;
-    if(charSet == "THAI17") return config.CHARCODE_THAI17;
-    if(charSet == "THAI18") return config.CHARCODE_THAI18;
-    return null;
-  } else {
-    // ------------------------------ Epson Character set ------------------------------
-    if(charSet == "USA") return config.CHARCODE_USA;
-    if(charSet == "FRANCE") return config.CHARCODE_FRANCE;
-    if(charSet == "GERMANY") return config.CHARCODE_GERMANY;
-    if(charSet == "UK") return config.CHARCODE_UK;
-    if(charSet == "DENMARK1") return config.CHARCODE_DENMARK1;
-    if(charSet == "SWEDEN") return config.CHARCODE_SWEDEN;
-    if(charSet == "ITALY") return config.CHARCODE_ITALY;
-    if(charSet == "SPAIN1") return config.CHARCODE_SPAIN1;
-    if(charSet == "JAPAN") return config.CHARCODE_JAPAN;
-    if(charSet == "NORWAY") return config.CHARCODE_NORWAY;
-    if(charSet == "DENMARK2") return config.CHARCODE_DENMARK2;
-    if(charSet == "SPAIN2") return config.CHARCODE_SPAIN2;
-    if(charSet == "LATINA") return config.CHARCODE_LATINA;
-    if(charSet == "KOREA") return config.CHARCODE_KOREA;
-    if(charSet == "SLOVENIA") return config.CHARCODE_SLOVENIA;
-    if(charSet == "CHINA") return config.CHARCODE_CHINA;
-    if(charSet == "VIETNAM") return config.CHARCODE_VIETNAM;
-    if(charSet == "ARABIA") return config.CHARCODE_ARABIA;
-    return null;
-  }
-};
-
-
-// ------------------------------ Merge objects ------------------------------
-var mergeObjects = function(obj1, obj2) {
-  var obj3 = {};
-  for (var attrname in obj1) { obj3[attrname] = obj1[attrname]; }
-  for (var attrname in obj2) { obj3[attrname] = obj2[attrname]; }
-  return obj3;
 };
 
 
@@ -520,68 +472,66 @@ var mergeObjects = function(obj1, obj2) {
  */
 function append(text) {
 
-    if (typeof text === "string") {
+  if (typeof text === "string") {
 
-        // Remove special characters.
-        if (printerConfig.removeSpecialCharacters) {
-            const unorm = require('unorm');
-            const combining = /[\u0300-\u036F]/g;
-            text = unorm.nfkd(text).replace(combining, '');
+    // Remove special characters.
+    if (printerConfig.removeSpecialCharacters) {
+      const unorm = require('unorm');
+      const combining = /[\u0300-\u036F]/g;
+      text = unorm.nfkd(text).replace(combining, '');
+    }
+
+    let endBuff = null;
+    for (const char of text) {
+
+      /**
+       * We only have to convert characters that are outside the ASCII range.
+       * @var {string|Buffer} code
+       */
+      let code = char;
+      if (!/^[\x00-\x7F]$/.test(char)) {
+
+        // Test if the active code page can print the current character.
+        try {
+          code = iconv.encode(char, config.CODE_PAGES[codePage]);
+        } catch (e) {
+          // Probably encoding not recognized.
+          console.error(e);
+          code = '?';
         }
 
-        let endBuff = null;
-        for (const char of text) {
+        if (code.toString() === '?') {
 
-            /**
-             * We only have to convert characters that are outside the ASCII range.
-             * @var {string|Buffer} code
-             */
-            let code = char;
-            if (!/^[\x00-\x7F]$/.test(char)) {
+          // Character not available in active code page, now try all other code pages.
+          for (const tmpCodePageKey of Object.keys(config.CODE_PAGES)) {
+            const tmpCodePage = config.CODE_PAGES[tmpCodePageKey];
 
-                // We only need iconv when we encounter non-ascii characters.
-                const iconv = require('iconv-lite');
-
-                // Test if the active code page can print the current character.
-                try {
-                    code = iconv.encode(char, config.CODE_PAGES[codePage][1]);
-                } catch (e) {
-                    // Probably encoding not recognized.
-                    console.error(e);
-                    code = '?';
-                }
-
-                if (code.toString() === '?') {
-
-                    // Character not available in active code page, now try all other code pages.
-                    for (const tmpCodePageKey of Object.keys(config.CODE_PAGES)) {
-                        const tmpCodePage = config.CODE_PAGES[tmpCodePageKey];
-
-                        try {
-                            code = iconv.encode(char, tmpCodePage[1]);
-                        } catch (e) {
-                            // Probably encoding not recognized.
-                            console.error(e);
-                        }
-
-                        if (code.toString() !== '?') {
-                            // We found a match, change active code page.
-                            codePage = tmpCodePageKey;
-                            code = Buffer.concat([tmpCodePage[0], code]);
-                            break;
-                        }
-                    }
-                }
+            try {
+              code = iconv.encode(char, tmpCodePage);
+            } catch (e) {
+              // Probably encoding not recognized.
+              console.error(e);
             }
-            endBuff = endBuff ? Buffer.concat([endBuff, Buffer.from(code)]) : Buffer.from(code);
-        }
-        text = endBuff;
-    }
 
-    // Append new buffer
-    if (buffer) {
-        buffer = Buffer.concat([buffer, text]);
-    } else {
-        buffer = text;
+            if (code.toString() !== '?') {
+
+              // We found a match, change active code page.
+              codePage = tmpCodePageKey;
+              code = Buffer.concat([config[`CODE_PAGE_${tmpCodePageKey}`], code]);
+              break;
+            }
+          }
+        }
+      }
+      endBuff = endBuff ? Buffer.concat([endBuff, Buffer.from(code)]) : Buffer.from(code);
     }
+    text = endBuff;
+  }
+
+  // Append new buffer
+  if (buffer) {
+    buffer = Buffer.concat([buffer, text]);
+  } else {
+    buffer = text;
+  }
 }

--- a/lib/epson.js
+++ b/lib/epson.js
@@ -3,6 +3,7 @@ let PNG = require('pngjs').PNG;
 let config = require('../configs/epsonConfig');
 
 let buffer = null;
+
 function append(buff) {
   if (buffer) buffer = Buffer.concat([buffer, buff]);
   else buffer = buff;
@@ -23,9 +24,9 @@ module.exports = {
     // [51 x33, micro qr code]
     // n2 = 0
     // https://reference.epson-biz.com/modules/ref_escpos/index.php?content_id=140
-    if(settings.model) {
-      if(settings.model === 1) append(config.QRCODE_MODEL1);
-      else if(settings.model === 3) append(config.QRCODE_MODEL3);
+    if (settings.model) {
+      if (settings.model === 1) append(config.QRCODE_MODEL1);
+      else if (settings.model === 3) append(config.QRCODE_MODEL3);
       else append(config.QRCODE_MODEL2);
     } else {
       append(config.QRCODE_MODEL2);
@@ -35,7 +36,7 @@ module.exports = {
     // 1D 28 6B 03 00 31 43 n
     // n depends on the printer
     // https://reference.epson-biz.com/modules/ref_escpos/index.php?content_id=141
-    if(settings.cellSize) {
+    if (settings.cellSize) {
       var i = "QRCODE_CELLSIZE_".concat(settings.cellSize.toString());
       append(config[i]);
     } else {
@@ -51,7 +52,7 @@ module.exports = {
     // [50 x32 -> 25%]
     // [51 x33 -> 30%]
     // https://reference.epson-biz.com/modules/ref_escpos/index.php?content_id=142
-    if(settings.correction) {
+    if (settings.correction) {
       var i = "QRCODE_CORRECTION_".concat(settings.correction.toUpperCase());
       append(config[i]);
     } else {
@@ -82,11 +83,11 @@ module.exports = {
 
 
   // ------------------------------ Epson PDF417 ------------------------------
-  pdf417: function(data, settings) {
+  pdf417: function (data, settings) {
     settings = settings || {};
 
     // Set error correction ratio 1 - 40
-    if(settings.correction){
+    if (settings.correction) {
       append(config.PDF417_CORRECTION);
       append(new Buffer([settings.correction]))
     } else {
@@ -95,7 +96,7 @@ module.exports = {
     }
 
     // Set row height 2 - 8
-    if(settings.rowHeight){
+    if (settings.rowHeight) {
       append(config.PDF417_ROW_HEIGHT);
       append(new Buffer([settings.rowHeight]))
     } else {
@@ -104,7 +105,7 @@ module.exports = {
     }
 
     // Set width of module 2 - 8
-    if(settings.width){
+    if (settings.width) {
       append(config.PDF417_WIDTH);
       append(new Buffer([settings.width]))
     } else {
@@ -113,7 +114,7 @@ module.exports = {
     }
 
     // Manually set columns 1 - 30
-    if(settings.columns){
+    if (settings.columns) {
       append(config.PDF417_COLUMNS);
       append(new Buffer([settings.columns]))
     } else {
@@ -123,7 +124,7 @@ module.exports = {
     }
 
     // Standard or truncated option
-    if(settings.truncated) append(config.PDF417_OPTION_TRUNCATED);
+    if (settings.truncated) append(config.PDF417_OPTION_TRUNCATED);
     else append(config.PDF417_OPTION_STANDARD);
 
     // Set PDF417 bar code data
@@ -144,7 +145,7 @@ module.exports = {
   },
 
   // ------------------------------ Epson CODE128 ------------------------------
-  maxiCode: function(data, settings){
+  maxiCode: function (data, settings) {
     settings = settings || {};
 
     // Maxi Mode
@@ -154,11 +155,11 @@ module.exports = {
     // 5 - Unformatted data/Enhanced Error Correction.
     // 6 - Used for programming hardware devices.
 
-    if(settings.mode) {
-      if(settings.mode == 2) append(config.MAXI_MODE2);
-      else if(settings.mode == 3) append(config.MAXI_MODE3);
-      else if(settings.mode == 5) append(config.MAXI_MODE5);
-      else if(settings.mode == 6) append(config.MAXI_MODE6);
+    if (settings.mode) {
+      if (settings.mode == 2) append(config.MAXI_MODE2);
+      else if (settings.mode == 3) append(config.MAXI_MODE3);
+      else if (settings.mode == 5) append(config.MAXI_MODE5);
+      else if (settings.mode == 6) append(config.MAXI_MODE6);
       else append(config.MAXI_MODE4)
     } else {
       append(config.MAXI_MODE4)
@@ -185,11 +186,11 @@ module.exports = {
 
 
   // ------------------------------ Epson BARCODE ------------------------------
-  printBarcode: function(data, type, settings){
+  printBarcode: function (data, type, settings) {
     settings = settings || {};
 
     //Set HRI characters Position, 0-3 (none, top, bottom, top/bottom)
-    if(settings.hriPos){
+    if (settings.hriPos) {
       append(new Buffer([0x1d, 0x48])); // GS H
       append(new Buffer([settings.hriPos]))
     } else {
@@ -197,7 +198,7 @@ module.exports = {
     }
 
     // Set HRI character font. 0-4, 48-52, 97, 98 (depending on printer, 0 and 1 available on all), default 0
-    if(settings.hriFont){
+    if (settings.hriFont) {
       append(new Buffer([0x1d, 0x66])); // GS f
       append(new Buffer([settings.hriFont]))
     } else {
@@ -205,7 +206,7 @@ module.exports = {
     }
 
     // Set width 2-6, default 3
-    if(settings.width){
+    if (settings.width) {
       append(new Buffer([0x1d, 0x77])); // GS W
       append(new Buffer([settings.width]))
     } else {
@@ -213,7 +214,7 @@ module.exports = {
     }
 
     // Set height 1 - 255 default 162
-    if(settings.height){
+    if (settings.height) {
       append(new Buffer([0x1d, 0x68])); // GS h
       append(new Buffer([settings.height]))
     } else {
@@ -235,27 +236,28 @@ module.exports = {
   },
 
 
-  // ----------------------------------------------------- PRINT IMAGE EPSON -----------------------------------------------------
+  // ----------------------------------------------------- PRINT IMAGE EPSON
+  // -----------------------------------------------------
   // https://reference.epson-biz.com/modules/ref_escpos/index.php?content_id=88
-  printImageEpson: function(image, callback){
+  printImageEpson: function (image, callback) {
     let png = new PNG({
       filterType: 4
     });
 
     fs.createReadStream(image)
-      .pipe(png)
-      .on('parsed', function() {
-        module.exports._printImageBufferEpson(this.width, this.height, this.data, function(buff){
-          callback(buff);
-        });
-      })
-      .on('error', function(err) {
-        console.error(err);
-      });
+            .pipe(png)
+            .on('parsed', function () {
+              module.exports._printImageBufferEpson(this.width, this.height, this.data, function (buff) {
+                callback(buff);
+              });
+            })
+            .on('error', function (err) {
+              console.error(err);
+            });
   },
 
 
-  _printImageBufferEpson: function(width, height, data, callback){
+  _printImageBufferEpson: function (width, height, data, callback) {
     // Get pixel rgba in 2D array
     var pixels = [];
     for (var i = 0; i < height; i++) {
@@ -273,15 +275,15 @@ module.exports = {
     }
 
 
-    var imageBuffer_array=[];
+    var imageBuffer_array = [];
     for (var i = 0; i < height; i++) {
-      for (var j = 0; j < Math.ceil(width/8); j++) {
+      for (var j = 0; j < Math.ceil(width / 8); j++) {
         var byte = 0x0;
         for (var k = 0; k < 8; k++) {
-          var pixel = pixels[i][j*8 + k];
+          var pixel = pixels[i][j * 8 + k];
 
           // Image overflow
-          if(pixel === undefined){
+          if (pixel === undefined) {
             pixel = {
               a: 0,
               r: 0,
@@ -290,11 +292,11 @@ module.exports = {
             };
           }
 
-          if(pixel.a > 126){ // checking transparency
+          if (pixel.a > 126) { // checking transparency
             var grayscale = parseInt(0.2126 * pixel.r + 0.7152 * pixel.g + 0.0722 * pixel.b);
 
-            if(grayscale < 128){ // checking color
-              var mask = 1 << 7-k; // setting bitwise mask
+            if (grayscale < 128) { // checking color
+              var mask = 1 << 7 - k; // setting bitwise mask
               byte |= mask; // setting the correct bit to 1
             }
           }
@@ -317,15 +319,15 @@ module.exports = {
     // https://reference.epson-biz.com/modules/ref_escpos/index.php?content_id=94
 
     // Check if width/8 is decimal
-    if(width%8 != 0) {
+    if (width % 8 != 0) {
       width += 8;
     }
 
-    append(new Buffer ([0x1d, 0x76, 0x30, 48]));
-    append(new Buffer ([(width >> 3) & 0xff]));
-    append(new Buffer ([0x00]));
-    append(new Buffer ([height & 0xff]));
-    append(new Buffer ([(height >> 8) & 0xff]));
+    append(new Buffer([0x1d, 0x76, 0x30, 48]));
+    append(new Buffer([(width >> 3) & 0xff]));
+    append(new Buffer([0x00]));
+    append(new Buffer([height & 0xff]));
+    append(new Buffer([(height >> 8) & 0xff]));
 
     // append data
     append(imageBuffer);

--- a/lib/star.js
+++ b/lib/star.js
@@ -3,6 +3,7 @@ let PNG = require('pngjs').PNG;
 let config = require('../configs/starConfig');
 
 let buffer = null;
+
 function append(buff) {
   if (buffer) buffer = Buffer.concat([buffer, buff]);
   else buffer = buff;
@@ -70,9 +71,10 @@ module.exports = {
     //	• Parameter details
     //	• nL + nH x 256: Byte count of bar code data
     //	• dk: Bar code data (Max. 7089 bytes)
-    //	• When using this command, the printer receives data for the number of bytes (k) specified by nL and nH. The data automatically expands to be set as the qr code data.
-    //	• Indicates the number bytes of data specified by the nL and nH. Bar code data is cleared at this time.
-    //	• The data storage region of this command is shared with the manual setting command so data is updated each time either command is executed.
+    //	• When using this command, the printer receives data for the number of bytes (k) specified by nL and nH. The
+    // data automatically expands to be set as the qr code data. • Indicates the number bytes of data specified by the
+    // nL and nH. Bar code data is cleared at this time. • The data storage region of this command is shared with the
+    // manual setting command so data is updated each time either command is executed.
     var s = str.length;
     var lsb = parseInt(s % 256);
     var msb = parseInt(s / 256);
@@ -85,8 +87,9 @@ module.exports = {
     // [Name] Print QR code
     // [Code] 1B 1D 79 50
     // [Function] Prints bar code data.
-    // When receiving this command, if there is unprinted data in the image buffer, the printer will print the bar code after printing the unprinted print data.
-    // A margin of more than 4 cells is required around the QR code. The user should ensure that space. Always check printed bar codes in actual use.
+    // When receiving this command, if there is unprinted data in the image buffer, the printer will print the bar code
+    // after printing the unprinted print data. A margin of more than 4 cells is required around the QR code. The user
+    // should ensure that space. Always check printed bar codes in actual use.
     append(config.QRCODE_PRINT);
 
 
@@ -98,7 +101,7 @@ module.exports = {
 
 
   // ------------------------------ Star PDF417 ------------------------------
-  pdf417: function(data, settings) {
+  pdf417: function (data, settings) {
     if (settings) {
       console.error('PDF417 settings not yet available for star printers!');
     }
@@ -149,7 +152,7 @@ module.exports = {
 
 
   // ------------------------------ Star CODE128 ------------------------------
-  code128: function(data, settings) {
+  code128: function (data, settings) {
     append(config.BARCODE_CODE128);
 
     // Barcode option
@@ -157,11 +160,11 @@ module.exports = {
     // 2 - Text on bottom
     // 3 - No text inline
     // 4 - Text on bottom inline
-    if(settings){
-      if(settings.text == 1) append(config.BARCODE_CODE128_TEXT_1);
-      else if(settings.text == 2) append(config.BARCODE_CODE128_TEXT_2);
-      else if(settings.text == 3) append(config.BARCODE_CODE128_TEXT_3);
-      else if(settings.text == 4) append(config.BARCODE_CODE128_TEXT_4);
+    if (settings) {
+      if (settings.text == 1) append(config.BARCODE_CODE128_TEXT_1);
+      else if (settings.text == 2) append(config.BARCODE_CODE128_TEXT_2);
+      else if (settings.text == 3) append(config.BARCODE_CODE128_TEXT_3);
+      else if (settings.text == 4) append(config.BARCODE_CODE128_TEXT_4);
     } else {
       append(config.BARCODE_CODE128_TEXT_2);
     }
@@ -170,7 +173,7 @@ module.exports = {
     // 31 - Small
     // 32 - Medium
     // 33 - Large
-    if(settings) {
+    if (settings) {
       if (settings.width == "SMALL") append(config.BARCODE_CODE128_WIDTH_SMALL);
       else if (settings.width == "MEDIUM") append(config.BARCODE_CODE128_WIDTH_MEDIUM);
       else if (settings.width == "LARGE") append(config.BARCODE_CODE128_WIDTH_LARGE);
@@ -179,7 +182,7 @@ module.exports = {
     }
 
     // Barcode height
-    if(settings && settings.height) append(new Buffer([settings.height]));
+    if (settings && settings.height) append(new Buffer([settings.height]));
     else append(new Buffer([0x50]));
 
     // Barcode data
@@ -195,19 +198,20 @@ module.exports = {
   },
 
 
-  // ----------------------------------------------------- PRINT IMAGE STAR -----------------------------------------------------
-  printImageStar: function(image, callback){
+  // ----------------------------------------------------- PRINT IMAGE STAR
+  // -----------------------------------------------------
+  printImageStar: function (image, callback) {
     fs.createReadStream(image).pipe(new PNG({
       filterType: 4
-    })).on('parsed', function() {
-      module.exports._printImageBufferStar(this.width, this.height, this.data, function(buff){
+    })).on('parsed', function () {
+      module.exports._printImageBufferStar(this.width, this.height, this.data, function (buff) {
         callback(buff);
       });
     });
   },
 
 
-  _printImageBufferStar: function(width, height, data, callback) {
+  _printImageBufferStar: function (width, height, data, callback) {
     // Get pixel rgba in 2D array
     var pixels = [];
     for (var i = 0; i < height; i++) {
@@ -227,22 +231,22 @@ module.exports = {
     append(new Buffer([0x1b, 0x30]));
 
     // v3
-    for(var i = 0; i < Math.ceil(height/24); i++){
+    for (var i = 0; i < Math.ceil(height / 24); i++) {
       var imageBuffer = new Buffer([]);
-      for(var y = 0; y < 24; y++){
+      for (var y = 0; y < 24; y++) {
 
-        for (var j = 0; j < Math.ceil(width/8); j++) {
+        for (var j = 0; j < Math.ceil(width / 8); j++) {
           var byte = 0x0;
 
           for (var x = 0; x < 8; x++) {
 
-            if((i*24 + y < pixels.length) && (j*8 + x < pixels[i*24 + y].length)){
-              var pixel = pixels[i*24 + y][j*8 + x];
-              if(pixel.a > 126){ // checking transparency
+            if ((i * 24 + y < pixels.length) && (j * 8 + x < pixels[i * 24 + y].length)) {
+              var pixel = pixels[i * 24 + y][j * 8 + x];
+              if (pixel.a > 126) { // checking transparency
                 var grayscale = parseInt(0.2126 * pixel.r + 0.7152 * pixel.g + 0.0722 * pixel.b);
 
-                if(grayscale < 128){ // checking color
-                  var mask = 1 << 7-x; // setting bitwise mask
+                if (grayscale < 128) { // checking color
+                  var mask = 1 << 7 - x; // setting bitwise mask
                   byte |= mask; // setting the correct bit to 1
                 }
               }
@@ -252,7 +256,7 @@ module.exports = {
           imageBuffer = Buffer.concat([imageBuffer, new Buffer([byte])]);
         }
       }
-      append(new Buffer([0x1b, 0x6b, parseInt(imageBuffer.length/24), 0x00]));
+      append(new Buffer([0x1b, 0x6b, parseInt(imageBuffer.length / 24), 0x00]));
       append(imageBuffer);
       append(new Buffer("\n"));
     }

--- a/package.json
+++ b/package.json
@@ -20,9 +20,13 @@
   },
   "homepage": "https://github.com/Klemen1337/node-thermal-printer",
   "dependencies": {
+    "iconv-lite": "^0.4.24",
     "net": "^1.0.2",
     "pngjs": "^3.2.0",
     "unorm": "^1.4.1",
     "write-file-queue": "0.0.1"
+  },
+  "devDependencies": {
+    "@types/node": "^10.11.7"
   }
 }


### PR DESCRIPTION
This improvement tries to match the unicode characters in the input string to the correct code page. Characters without a match are printed as question mark (?). 

So eg if the user tries to print a Euro currency sign, it will make the translation from Euro in text to the correct code automatically. No need to find and print the character code for Euro. The user never has the need to deal with any of the character set or code page junk anymore - they just send unicode UTF8 strings and the library deals with it.

It adds a dependency to iconv-lite. 
Also still plan to add some unit tests.