### PR TITLE
Prevents connection callback being fired twice - fixes #64

### DIFF
--- a/interfaces/net.js
+++ b/interfaces/net.js
@@ -17,7 +17,7 @@ NetPrint.prototype.execute = function(buffer, cb) {
       if (typeof cb !== "undefined") {
         cb(null);
       }
-      printer.end();
+      printer.destroy();
     });
   });
 
@@ -25,14 +25,14 @@ NetPrint.prototype.execute = function(buffer, cb) {
     if (typeof cb !== "undefined") {
       cb(err);
     }
-    printer.end();
+    printer.destroy();
   });
 
   printer.on('timeout', function () {
     if (typeof cb !== "undefined") {
       cb("Error: Socket Timeout");
     }
-    printer.end();
+    printer.destroy();
   });
 };
 
@@ -44,17 +44,17 @@ NetPrint.prototype.isPrinterConnected = function(exists){
     timeout: this.timeout
   }, function() {
     exists(true);
-    printer.end();
+    printer.destroy();
   });
 
-  printer.on('error', function (err) {
+  printer.on('error', function () {
     exists(false);
-    printer.end();
+    printer.destroy();
   });
-  
+
   printer.on('timeout', function () {
     exists(false);
-    printer.end();
+    printer.destroy();
   });
 };
 


### PR DESCRIPTION
It prevents the timeout from firing by destroying the socket immediately after use.

This fixes #64