### PR TITLE
adding promises to printImage function

### DIFF
--- a/lib/types/epson.js
+++ b/lib/types/epson.js
@@ -251,16 +251,18 @@ class Epson extends PrinterType {
   // ----------------------------------------------------- PRINT IMAGE -----------------------------------------------------
   // https://reference.epson-biz.com/modules/ref_escpos/index.php?content_id=88
   async printImage(image) {
-    let fs = require('fs');
-    let PNG = require('pngjs').PNG;
-    try {
-      var data = fs.readFileSync(image);
-      var png = PNG.sync.read(data);
-      let buff = this.printImageBuffer(png.width, png.height, png.data);
-      return buff;
-    } catch (error) {
-      throw error;
-    }
+    return new Promise(function(resolve,reject){
+      let fs = require('fs');
+      let PNG = require('pngjs').PNG;
+      try {
+        var data = fs.readFileSync(image);
+        var png = PNG.sync.read(data);
+        let buff = this.printImageBuffer(png.width, png.height, png.data);
+        resolve(buff);
+      } catch (error) {
+        reject(error);
+      }
+    });
   }
 
 

--- a/lib/types/star.js
+++ b/lib/types/star.js
@@ -228,16 +228,22 @@ class Star extends PrinterType {
 
   // ----------------------------------------------------- PRINT IMAGE -----------------------------------------------------
   async printImage(image) {
-    let fs = require('fs');
-    let PNG = require('pngjs').PNG;
-    try {
-      var data = fs.readFileSync(image);
-      var png = PNG.sync.read(data);
-      let buff = this.printImageBuffer(png.width, png.height, png.data);
-      return buff;
-    } catch(error) {
-      throw error;
-    }
+    return new Promise(function(resolve, reject) {
+      let fs = require("fs");
+      let PNG = require("pngjs").PNG;
+      try {
+        var data = fs.readFileSync(image);
+        var png = PNG.sync.read(data);
+        let buff = this.printImageBuffer(
+          png.width,
+          png.height,
+          png.data
+        );
+        resolve(buff);
+      } catch (error) {
+        reject(error);
+      }
+    });
   }
 
 


### PR DESCRIPTION
When printing an image, if this one is not small enough, the commands keep going and doesn't wait for the buffer to read and the image to print.
That's why adding promises to this function is something required, for example, printing a ticket with the company logo in the head and a QR before the ending of the ticket.