### PR TITLE
Add support for printing JPEG images

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -371,8 +371,14 @@ class ThermalPrinter {
       // Check if file exists
       fs.accessSync(image);
 
+      let extention = image.split('.').pop();
+
       // Check for file type
-      if (image.slice(-4) === ".png") {
+      if (
+        extention === "png" ||
+        extention === "jpg" ||
+        extention === "jpeg"
+      ) {
         try {
           let response = await this.printer.printImage(image);
           this.append(response);
@@ -381,7 +387,7 @@ class ThermalPrinter {
           throw error;
         }
       } else {
-        throw new Error("Image printing supports only PNG files.");
+        throw new Error("Image printing supports only PNG and JPEG files.");
       }
     } catch (error) {
       throw error;

--- a/lib/types/epson.js
+++ b/lib/types/epson.js
@@ -250,14 +250,28 @@ class Epson extends PrinterType {
 
   // ----------------------------------------------------- PRINT IMAGE -----------------------------------------------------
   // https://reference.epson-biz.com/modules/ref_escpos/index.php?content_id=88
-  async printImage(image) {
+  printImage(imagePath) {
     let fs = require('fs');
-    let PNG = require('pngjs').PNG;
+
+    let extention = imagePath.split('.').pop();
+
     try {
-      var data = fs.readFileSync(image);
-      var png = PNG.sync.read(data);
-      let buff = this.printImageBuffer(png.width, png.height, png.data);
-      return buff;
+      let image = null;
+      let file = fs.readFileSync(imagePath);
+
+      if (extention === 'png') {
+        let PNG = require('pngjs').PNG;
+        image = PNG.sync.read(file);
+      } else {
+        let jpeg = require('jpeg-js');
+        image = jpeg.decode(file);
+      }
+
+      if (image == null) {
+        throw "Could not read image.";
+      }
+
+      return this.printImageBuffer(image.width, image.height, image.data);
     } catch (error) {
       throw error;
     }

--- a/lib/types/star.js
+++ b/lib/types/star.js
@@ -5,7 +5,7 @@ class Star extends PrinterType {
     super();
     this.config = require('./star-config');
   }
-  
+
 
   // ------------------------------ Append ------------------------------
   append(appendBuffer) {
@@ -227,15 +227,29 @@ class Star extends PrinterType {
 
 
   // ----------------------------------------------------- PRINT IMAGE -----------------------------------------------------
-  async printImage(image) {
+  printImage(imagePath) {
     let fs = require('fs');
-    let PNG = require('pngjs').PNG;
+
+    let extention = imagePath.split('.').pop();
+
     try {
-      var data = fs.readFileSync(image);
-      var png = PNG.sync.read(data);
-      let buff = this.printImageBuffer(png.width, png.height, png.data);
-      return buff;
-    } catch(error) {
+      let image = null;
+      let file = fs.readFileSync(imagePath);
+
+      if (extention === 'png') {
+        let PNG = require('pngjs').PNG;
+        image = PNG.sync.read(file);
+      } else {
+        let jpeg = require('jpeg-js');
+        image = jpeg.decode(file);
+      }
+
+      if (image == null) {
+        throw "Could not read image.";
+      }
+
+      return this.printImageBuffer(image.width, image.height, image.data);
+    } catch (error) {
       throw error;
     }
   }
@@ -304,17 +318,17 @@ class Star extends PrinterType {
 
     // [Name] ESC b n1 n2 n3 n4 d1...dk RS
     // [Code] Hex. 1B 62 n1 n2 n3 n4 d1 ... dk 1E
-    // [Defined Area] 
+    // [Defined Area]
     //   n1 (Barcode type): 0≤n1≤8, 48≤n1≤56 (0≤n1≤8)
     //   n2 (Barcode under-bar): 1≤n2≤4, 49≤n2≤52 (1≤n2≤4)
     //   n3 (Barcode mode),
     //   n4 (Barcode height) 1≤n4≤255
-    //   d  (Barcode data), 
+    //   d  (Barcode data),
     //   k  (Barcode data count) definitions differ according to the type of barcode.
     //   RS
-    // [Function] 
+    // [Function]
     //   Barcode printing is executed according to the following parameters.
-    //   If n1, n2, n3 and n4 are acquired and detected to be out of the defined area, data up to RS is discarded. 
+    //   If n1, n2, n3 and n4 are acquired and detected to be out of the defined area, data up to RS is discarded.
     this.append(Buffer.from([0x1b, 0x62]));
 
 
@@ -431,10 +445,10 @@ class Star extends PrinterType {
     //   The check character (“□”) is automatically applied.
     //
     // • NW7: k is freely set, and maximum value differs according to the mode and the print character type.
-    
+
     // NOTE: Not needed.
     // this.append(Buffer.from([data.length]));
-    
+
 
     // Start/stop codes included in the data (not automatically applied).
     this.append(Buffer.from([0x1e]));

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "homepage": "https://github.com/Klemen1337/node-thermal-printer",
   "dependencies": {
     "iconv-lite": "0.5.0",
+    "jpeg-js": "^0.3.6",
     "pngjs": "3.3.3",
     "unorm": "1.4.1",
     "write-file-queue": "0.0.1"


### PR DESCRIPTION
Extended the `printImage()` function to add support for printing `jpeg` files. Tested on an Epson TM-T88III. Maybe someone should test it on a Star printer.