### PR TITLE
Updated core.js to save PrinterType in it's this.config

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -25,6 +25,7 @@ class ThermalPrinter {
     }
 
     this.config = {
+      type: initConfig.type,
       width: parseInt(initConfig.width) || 48,
       characterSet: initConfig.characterSet || "SLOVENIA",
       removeSpecialCharacters: initConfig.removeSpecialCharacters || false,


### PR DESCRIPTION
The printertype is now saved in the config options allowing STAR printers to open the cash drawer instead of it using the EPSON CD_KICK2 and CD_KICK5 because we passed over the if statement.