### PR TITLE
feat: add KOREA code page

### DIFF
--- a/lib/types/epson-config.js
+++ b/lib/types/epson-config.js
@@ -86,6 +86,7 @@ module.exports = {
   CODE_PAGE_WPC1258_VIETNAMESE    : Buffer.from([0x1b, 0x74, 52]),
   CODE_PAGE_KZ1048_KAZAKHSTAN     : Buffer.from([0x1b, 0x74, 53]),
   CODE_PAGE_JAPAN                 : Buffer.from([0x1b, 0x52, 0x08]),
+  CODE_PAGE_KOREA                 : Buffer.from([0x1b, 0x52, 0x0D]),
   CODE_PAGE_CHINA                 : Buffer.from([0x1b, 0x52, 0x0F]),
   CODE_PAGE_HK_TW                 : Buffer.from([0x1b, 0x52, 0x00]),
 
@@ -126,6 +127,7 @@ module.exports = {
     WPC1258_VIETNAMESE    : 'WIN1258',
     KZ1048_KAZAKHSTAN     : 'RK1048',
     JAPAN                 : 'EUC-JP',
+    KOREA                 : 'EUC-KR',
     CHINA                 : 'EUC-CN',
     HK_TW                 : 'Big5-HKSCS'
   },

--- a/lib/types/star-config.js
+++ b/lib/types/star-config.js
@@ -87,6 +87,7 @@ module.exports = {
   CODE_PAGE_WPC1258_VIETNAMESE    : Buffer.from([0x1b, 0x74, 52]),
   CODE_PAGE_KZ1048_KAZAKHSTAN     : Buffer.from([0x1b, 0x74, 53]),
   CODE_PAGE_JAPAN                 : Buffer.from([0x1b, 0x52, 0x08]),
+  CODE_PAGE_KOREA                 : Buffer.from([0x1b, 0x52, 0x0D]),
   CODE_PAGE_CHINA                 : Buffer.from([0x1b, 0x52, 0x0F]),
 
   // Character code pages / iconv name of code table.
@@ -126,6 +127,7 @@ module.exports = {
     WPC1258_VIETNAMESE    : 'WIN1258',
     KZ1048_KAZAKHSTAN     : 'RK1048',
     JAPAN                 : 'EUC-JP',
+    KOREA                 : 'EUC-KR',
     CHINA                 : 'EUC-CN'
   },
 


### PR DESCRIPTION
Question marks appear when printing Korean, so the KOREA code page option has been added. Tested on an Epson TM-T81.