### PR TITLE
Update printer.js to return correct isPrinterConnected status

### DIFF
--- a/lib/interfaces/printer.js
+++ b/lib/interfaces/printer.js
@@ -28,9 +28,9 @@ class Printer extends Interface {
     return name;
   }
 
-
   async isPrinterConnected () {
-    if (this.driver.getPrinter(this.getPrinterName())) {
+    const foundPrinter = this.driver.getPrinter(this.getPrinterName());
+    if (foundPrinter && foundPrinter.status.indexOf('NOT-AVAILABLE') === -1) {
       return true;
     } else {
       throw false;


### PR DESCRIPTION
Currently this function always returns true as the printer is always found in the system printers list. It should check the printer's status i.e. 'NOT AVAILABLE' means the printer is not connected.