### PR TITLE
Support Encoding "TCVN_VIETNAMESE"

### DIFF
--- a/lib/types/epson-config.js
+++ b/lib/types/epson-config.js
@@ -89,6 +89,7 @@ module.exports = {
   CODE_PAGE_KOREA                 : Buffer.from([0x1b, 0x52, 0x0D]),
   CODE_PAGE_CHINA                 : Buffer.from([0x1b, 0x52, 0x0F]),
   CODE_PAGE_HK_TW                 : Buffer.from([0x1b, 0x52, 0x00]),
+  CODE_PAGE_TCVN_VIETNAMESE       : Buffer.from([0x1b, 0x74, 52]),
 
   // Character code pages / iconv name of code table.
   // Only code pages supported by iconv-lite:
@@ -129,7 +130,8 @@ module.exports = {
     JAPAN                 : 'EUC-JP',
     KOREA                 : 'EUC-KR',
     CHINA                 : 'EUC-CN',
-    HK_TW                 : 'Big5-HKSCS'
+    HK_TW                 : 'Big5-HKSCS',
+    TCVN_VIETNAMESE       : 'tcvn'
   },
 
   // Barcode format


### PR DESCRIPTION
- Support Vietnamese printing (Encoding TCVN)
- Successfully tested on Xprinter 80mm (Model R200EU)