### PR TITLE
Fixed printing code 128 barcodes

### DIFF
--- a/lib/types/epson.js
+++ b/lib/types/epson.js
@@ -232,7 +232,15 @@ class Epson extends PrinterType {
     // Print Barcode
     this.append(Buffer.from([0x1d, 0x6b])); // GS k
     // Select type and bit length of data
-    this.append(Buffer.from([type, data.length]));
+    if(type == 73)
+    {
+      this.append(Buffer.from([type, data.length + 2]));
+      this.append(Buffer.from([0x7b, 0x42]));
+    }
+    else
+    {
+      this.append(Buffer.from([type, data.length]));
+    }
     // Data
     this.append(Buffer.from(data));
 


### PR DESCRIPTION
Implemented hesa2020's fix for printing code 128 barcodes