### PR TITLE
Keep initial CharacterSet after .clear()

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -77,11 +77,14 @@ class ThermalPrinter {
         this.printer = new Epson();
         break;
     }
+    
+    const initialCharacterSet = initConfig.characterSet || CharacterSet.SLOVENIA
 
     this.config = {
       type: initConfig.type,
       width: parseInt(initConfig.width) || 48,
-      characterSet: initConfig.characterSet || CharacterSet.SLOVENIA,
+      initialCharacterSet: initialCharacterSet,
+      characterSet: initialCharacterSet,
       removeSpecialCharacters: initConfig.removeSpecialCharacters || false,
       lineCharacter: initConfig.lineCharacter || '-',
       breakLine: initConfig.breakLine || BreakLine.WORD,
@@ -136,6 +139,7 @@ class ThermalPrinter {
 
   clear() {
     this.buffer = null;
+    this.setCharacterSet(this.config.initialCharacterSet);
   }
 
   add(buffer) {


### PR DESCRIPTION
At the moment I need to run `printer.setCharacterSet(characterSet);` every time after `printer.clear()`. This is confusing behaviour when the characterSet was initially selected when calling the `new ThermalPrinter({ characterSet })`-constructor.

This proposed change adds an extra prop to the config-object (`config.initialCharacterSet`) and calls `this.setCharacterSet(this.config.initialCharacterSet)` from within the `.clear`-method, in order to keep the initial characterSet