### PR TITLE
Removed console.log when printing

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -147,7 +147,6 @@ class ThermalPrinter {
     if (this.config.breakLine != BreakLine.NONE) { // Break lines
       text = this._fold(text, this.config.width, this.config.breakLine == BreakLine.CHARACTER).join("\n");
     }
-    console.log(text)
     this.append(text.toString());
   }
 


### PR DESCRIPTION
Introduced [here](https://github.com/Klemen1337/node-thermal-printer/blob/bd63eceb748a5a72822970a705a4d687e053c5d7/lib/core.js#L150) maybe for debugging?