### PR TITLE
add encoding for TIS11 and TIS66 code pages (Thai language)

### DIFF
--- a/lib/types/epson-config.js
+++ b/lib/types/epson-config.js
@@ -132,6 +132,8 @@ module.exports = {
     CHINA: 'EUC-CN',
     HK_TW: 'Big5-HKSCS',
     TCVN_VIETNAMESE: 'tcvn',
+    TIS11_THAI: 'TIS-620',
+    TIS18_THAI: 'TIS-620',
   },
 
   // Barcode format


### PR DESCRIPTION
For Thai language, iconv-lite support only TIS-620 encode. I added to code pages config to make iconv encoding pass.