### PR TITLE
add Daruma cash drawer kick codes; fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Node Thermal Printer
 
-Node.js module for Epson, Star, Tanca, Drauma, and Brother thermal printers command line printing.
+Node.js module for Epson, Star, Tanca, Daruma, and Brother thermal printers command line printing.
 
 [![Join the chat at https://gitter.im/Klemen1337/node-thermal-printer](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/Klemen1337/node-thermal-printer?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
@@ -106,7 +106,7 @@ Network printer
 node examples/example.js tcp://xxx.xxx.xxx.xxx
 ```
 
-Pritner name via Printer module
+Printer name via Printer module
 
 ```bash
 node examples/example.js 'printer:My Printer'
@@ -329,6 +329,7 @@ printer.printBarcode(data, type, settings);
 - EPSON TM-T82IIIL
 - Posman BTP-R880NP (Type "epson")
 - Brother TD-4550DNWB
+- Daruma DR800
 
 ## Character sets
 

--- a/lib/types/daruma-config.js
+++ b/lib/types/daruma-config.js
@@ -13,6 +13,10 @@ module.exports = {
   HW_RESET: Buffer.from([0x1b, 0x3f, 0x0a, 0x00]), // Reset printer hardware
   BEEP: Buffer.from([0x07]), // Sounds built-in buzzer (if equipped)
 
+  // Cash Drawer
+  CD_KICK_2: Buffer.from([0x1b, 0x70, 0x00]), // Sends a pulse to pin 2 []
+  CD_KICK_5: Buffer.from([0x1b, 0x70, 0x01]), // Sends a pulse to pin 5 []
+
   // Paper
   PAPER_FULL_CUT: Buffer.from([0x1b, 0x6d]), // Full cut paper
   PAPER_PART_CUT: Buffer.from([0x1b, 0x6d]), // Partial cut paper

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-thermal-printer",
   "version": "4.4.1",
-  "description": "Print on Epson, Star, Tranca, Drauma and Brother thermal printers with NodeJS",
+  "description": "Print on Epson, Star, Tranca, Daruma and Brother thermal printers with Node.js",
   "main": "node-thermal-printer.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
* Fixing the typos "Drauma" to "Daruma". It must also be updated in the repository description.
* Added the missing cash drawer kick codes.

Here is a print test on Daruma DR800:
 
[<img alt="Daruma test" src="https://github.com/Klemen1337/node-thermal-printer/assets/26308880/b280d123-e411-4102-a70e-91edd023a33b" width="400px">](https://github.com/Klemen1337/node-thermal-printer/assets/26308880/b280d123-e411-4102-a70e-91edd023a33b)
