### PR TITLE
Accept an optional character on `drawLine`

### DIFF
--- a/examples/example.js
+++ b/examples/example.js
@@ -66,6 +66,9 @@ async function example() {
   printer.setTextNormal();
   printer.println('This is normal');
   printer.drawLine();
+  
+  printer.println('Draw a line with a custom character');
+  printer.drawLine('=');
 
   try {
     printer.printBarcode('4126570807191');

--- a/lib/core.js
+++ b/lib/core.js
@@ -265,10 +265,9 @@ class ThermalPrinter {
   }
 
   // ----------------------------------------------------- DRAW LINE -----------------------------------------------------
-  drawLine() {
-    // this.newLine();
+  drawLine(character = this.config.lineCharacter) {
     for (let i = 0; i < this.config.width; i++) {
-      this.append(Buffer.from(this.config.lineCharacter));
+      this.append(Buffer.from(character));
     }
     this.newLine();
   }

--- a/node-thermal-printer.d.ts
+++ b/node-thermal-printer.d.ts
@@ -253,8 +253,9 @@ declare class ThermalPrinter {
 
   /**
     * Draw a line of characters
+    * @param String optional character to be repeated
   */
-  drawLine(): void;
+  drawLine(character?: string): void;
 
   /**
    * Set height and width font size


### PR DESCRIPTION
This is useful when you want to print different lines in the same document, e.g.:

```
                      TITLE
================================================
Some content
goes here
------------------------------------------------
another content
...
================================================
                      FOOTER
```