### PR TITLE
Fix resolver execute promise

### DIFF
--- a/lib/interfaces/network.js
+++ b/lib/interfaces/network.js
@@ -52,6 +52,7 @@ class Network extends Interface {
             console.log(`Data sent to printer: ${name}`, buffer);
             if (!options.waitForResponse) {
               networkConnection.destroy();
+              resolve();
             }
           });
         }


### PR DESCRIPTION
This fix resolves promises after the execute() method for network interface. If resolve() is not called, the promise is never fulfilled failing because of timeout.