### PR TITLE
Support Encoding "viscii"

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -54,6 +54,7 @@ const CharacterSet = {
   CHINA: 'CHINA',
   HK_TW: 'HK_TW',
   TCVN_VIETNAMESE: 'TCVN_VIETNAMESE',
+  VISCII: 'VISCII'
 };
 
 class ThermalPrinter {

--- a/lib/types/custom-config.js
+++ b/lib/types/custom-config.js
@@ -91,6 +91,7 @@ module.exports = {
   CODE_PAGE_CHINA: Buffer.from([0x1b, 0x52, 0x0F]),
   CODE_PAGE_HK_TW: Buffer.from([0x1b, 0x52, 0x00]),
   CODE_PAGE_TCVN_VIETNAMESE: Buffer.from([0x1b, 0x74, 52]),
+  CODE_PAGE_VISCII: Buffer.from([0x1b, 0x74, 52]),
 
   // Character code pages / iconv name of code table.
   // Only code pages supported by iconv-lite:

--- a/lib/types/custom-config.js
+++ b/lib/types/custom-config.js
@@ -135,6 +135,7 @@ module.exports = {
     TCVN_VIETNAMESE: 'tcvn',
     TIS11_THAI: 'TIS-620',
     TIS18_THAI: 'TIS-620',
+    VISCII: 'viscii'
   },
 
   // Barcode format

--- a/lib/types/daruma-config.js
+++ b/lib/types/daruma-config.js
@@ -84,7 +84,7 @@ module.exports = {
   CODE_PAGE_CHINA: Buffer.from([0x1b, 0x52, 0x0F]),
   CODE_PAGE_HK_TW: Buffer.from([0x1b, 0x52, 0x00]),
   CODE_PAGE_TCVN_VIETNAMESE: Buffer.from([0x1b, 0x74, 52]),
-
+  CODE_PAGE_VISCII: Buffer.from([0x1b, 0x74, 52]),
   // Character code pages / iconv name of code table.
   // Only code pages supported by iconv-lite:
   // https://github.com/ashtuchkin/iconv-lite/wiki/Supported-Encodings

--- a/lib/types/daruma-config.js
+++ b/lib/types/daruma-config.js
@@ -126,5 +126,6 @@ module.exports = {
     CHINA: 'EUC-CN',
     HK_TW: 'Big5-HKSCS',
     TCVN_VIETNAMESE: 'tcvn',
+    VISCII: 'viscii'
   }
 };

--- a/lib/types/epson-config.js
+++ b/lib/types/epson-config.js
@@ -91,6 +91,7 @@ module.exports = {
   CODE_PAGE_CHINA: Buffer.from([0x1b, 0x52, 0x0F]),
   CODE_PAGE_HK_TW: Buffer.from([0x1b, 0x52, 0x00]),
   CODE_PAGE_TCVN_VIETNAMESE: Buffer.from([0x1b, 0x74, 52]),
+  CODE_PAGE_VISCII: Buffer.from([0x1b, 0x74, 52]),
 
   // Character code pages / iconv name of code table.
   // Only code pages supported by iconv-lite:

--- a/lib/types/epson-config.js
+++ b/lib/types/epson-config.js
@@ -135,7 +135,7 @@ module.exports = {
     TCVN_VIETNAMESE: 'tcvn',
     TIS11_THAI: 'TIS-620',
     TIS18_THAI: 'TIS-620',
-    VISCII: 'viscii',
+    VISCII: 'viscii'
   },
 
   // Barcode format

--- a/lib/types/epson-config.js
+++ b/lib/types/epson-config.js
@@ -135,6 +135,7 @@ module.exports = {
     TCVN_VIETNAMESE: 'tcvn',
     TIS11_THAI: 'TIS-620',
     TIS18_THAI: 'TIS-620',
+    VISCII: 'viscii',
   },
 
   // Barcode format

--- a/node-thermal-printer.d.ts
+++ b/node-thermal-printer.d.ts
@@ -58,7 +58,8 @@ declare enum CharacterSet {
   KOREA = 'KOREA',
   CHINA = 'CHINA',
   HK_TW = 'HK_TW',
-  TCVN_VIETNAMESE = 'TCVN_VIETNAMESE'
+  TCVN_VIETNAMESE = 'TCVN_VIETNAMESE',
+  VISCII = 'VISCII'
 }
 
 declare type CutOptions = {


### PR DESCRIPTION
- Vietnamese (encoding **viscii**) supported
- I tried it on my thermal printer ([Zywell ZY-Q821](https://www.zywell.com/pos-printer/80mm-receipt-printer/thermal-printer-bluetooth-80mm.html))
```
const printer = new ThermalPrinter({
    type: PrinterTypes.EPSON,
    interface: "printer:POS-80C",
    driver, 
    characterSet: CharacterSet.VISCII, 
});
```
Result:
![dsadsadsa](https://github.com/user-attachments/assets/fe6409ff-55bf-4d01-ac97-2608ce6d9c58)
