### PR TITLE
Add setLineSpacing() and resetLineSpacing() methods [EPSON]

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -274,6 +274,15 @@ class ThermalPrinter {
     this.append(this.printer.config.CTL_LF);
   }
 
+  // ----------------------------------------------------- LINE SPACING -----------------------------------------------------
+  setLineSpacing (spacing) {
+    this.append(this.printer.setLineSpacing(spacing));
+  }
+
+  resetLineSpacing () {
+    this.append(this.printer.config.LINE_SPACING_DEFAULT);
+  }
+
   // ----------------------------------------------------- DRAW LINE -----------------------------------------------------
   drawLine (character = this.config.lineCharacter) {
     for (let i = 0; i < this.config.width; i++) {

--- a/lib/types/epson-config.js
+++ b/lib/types/epson-config.js
@@ -7,6 +7,9 @@ module.exports = {
   CTL_SET_HT: Buffer.from([0x1b, 0x44]), // Set horizontal tab positions
   CTL_VT: Buffer.from([0x1b, 0x64, 0x04]), // Vertical tab
 
+  // Line spacing
+  LINE_SPACING_DEFAULT: Buffer.from([0x1b, 0x32]), // ESC 2 - Reset to default line spacing
+
   // Printer hardware
   HW_INIT: Buffer.from([0x1b, 0x40]), // Clear data in buffer and reset modes
   HW_SELECT: Buffer.from([0x1b, 0x3d, 0x01]), // Printer select

--- a/lib/types/epson.js
+++ b/lib/types/epson.js
@@ -44,6 +44,17 @@ class Epson extends PrinterType {
     return this.buffer;
   }
 
+  // ------------------------------ Set line spacing ------------------------------
+  setLineSpacing (spacing) {
+    this.buffer = null;
+    if (spacing < 0 || spacing > 255) {
+      throw new Error('setLineSpacing: Spacing must be between 0 and 255');
+    }
+    // ESC 3 n - Set line spacing to n dots
+    this.append(Buffer.from([0x1b, 0x33, spacing]));
+    return this.buffer;
+  }
+
   // ------------------------------ CODE 128 ------------------------------
   code128 (data, settings) {
     this.buffer = null;

--- a/lib/types/printer-type.js
+++ b/lib/types/printer-type.js
@@ -42,6 +42,11 @@ class PrinterType {
     console.error(new Error("'printImageBuffer' not implemented yet"));
     return null;
   }
+
+  setLineSpacing (spacing) {
+    console.error(new Error("'setLineSpacing' not implemented for this printer type"));
+    return null;
+  }
 }
 
 module.exports = PrinterType;

--- a/node-thermal-printer.d.ts
+++ b/node-thermal-printer.d.ts
@@ -261,6 +261,17 @@ declare class ThermalPrinter {
   newLine(): void;
 
   /**
+   * Set line spacing in dots (0-255)
+   * @param spacing Line spacing value in dots
+   */
+  setLineSpacing(spacing: number): void;
+
+  /**
+   * Reset line spacing to printer default
+   */
+  resetLineSpacing(): void;
+
+  /**
     * Draw a line of characters
     * @param String optional character to be repeated
   */


### PR DESCRIPTION
Adds support for controlling line spacing via ESC/POS commands:

- `setLineSpacing(spacing)` - Set line spacing in dots (0-255) using ESC 3 n command
- `resetLineSpacing()` - Reset to default line spacing using ESC 2 command

Example:
```js
printer.resetLineSpacing();
printer.println('Normal line spacing');
printer.println('Normal line spacing');
printer.println('Normal line spacing');
printer.println('Normal line spacing');

printer.newLine();
printer.drawLine();
printer.newLine();

printer.setLineSpacing(40);
printer.println('Custom line spacing');
printer.println('Custom line spacing');
printer.println('Custom line spacing');
printer.println('Custom line spacing');
```

Changes:
- Implemented for Epson printer type
- Added stub for other printer types
- Updated TypeScript definitions

Happy to adjust anything...