### PR TITLE
await driver methods

### DIFF
--- a/lib/interfaces/interface.js
+++ b/lib/interfaces/interface.js
@@ -1,5 +1,5 @@
 class Interface {
-  getPrinterName () {
+  async getPrinterName () {
     throw new Error("'getPrinterName' function not implemented.");
   }
 

--- a/lib/interfaces/printer.js
+++ b/lib/interfaces/printer.js
@@ -11,10 +11,11 @@ class Printer extends Interface {
     }
   }
 
-  getPrinterName () {
+  async getPrinterName () {
     let { name } = this;
     if (!name || name === 'auto') {
-      const pl = this.driver.getPrinters().filter((p) => p.attributes.indexOf('RAW-ONLY') > -1);
+      const printers = await this.driver.getPrinters();
+      const pl = printers.filter((p) => p.attributes.indexOf('RAW-ONLY') > -1);
       if (pl.length > 0) {
         name = pl[0].name;
       }
@@ -26,7 +27,8 @@ class Printer extends Interface {
   }
 
   async isPrinterConnected () {
-    const foundPrinter = await this.driver.getPrinter(this.getPrinterName());
+    const printerName = await this.getPrinterName();
+    const foundPrinter = await this.driver.getPrinter(printerName);
     if (foundPrinter && foundPrinter.status.indexOf('NOT-AVAILABLE') === -1) {
       return true;
     }
@@ -34,10 +36,11 @@ class Printer extends Interface {
   }
 
   async execute (buffer, options = {}) {
+    const printerName = await this.getPrinterName();
     return new Promise((resolve, reject) => {
       this.driver.printDirect({
         data: buffer,
-        printer: this.getPrinterName(),
+        printer: printerName,
         type: 'RAW',
         docname: options.docname !== undefined ? options.docname : false,
         success (jobID) {

--- a/lib/interfaces/printer.js
+++ b/lib/interfaces/printer.js
@@ -26,7 +26,7 @@ class Printer extends Interface {
   }
 
   async isPrinterConnected () {
-    const foundPrinter = this.driver.getPrinter(this.getPrinterName());
+    const foundPrinter = await this.driver.getPrinter(this.getPrinterName());
     if (foundPrinter && foundPrinter.status.indexOf('NOT-AVAILABLE') === -1) {
       return true;
     }


### PR DESCRIPTION
For USB connected printers,

- await driver.getPrinter in `isPrinterConnected` method.
- await driver.getPrinters in `getPrinterName` 
- update printer retrieval in isPrinterConnected and execute methods